### PR TITLE
Replaced strcpy(if_name, argv[x])+ioctl …

### DIFF
--- a/canfdtest.c
+++ b/canfdtest.c
@@ -312,7 +312,6 @@ static int can_echo_gen(void)
 
 int main(int argc, char *argv[])
 {
-	struct ifreq ifr;
 	struct sockaddr_can addr;
 	char *intf_name;
 	int family = PF_CAN, type = SOCK_RAW, proto = CAN_RAW;
@@ -356,9 +355,7 @@ int main(int argc, char *argv[])
 	}
 
 	addr.can_family = family;
-	strcpy(ifr.ifr_name, intf_name);
-	ioctl(sockfd, SIOCGIFINDEX, &ifr);
-	addr.can_ifindex = ifr.ifr_ifindex;
+	addr.can_ifindex = if_nametoindex(intf_name);
 
 	if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		perror("bind");

--- a/cansend.c
+++ b/cansend.c
@@ -94,8 +94,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	strncpy(ifr.ifr_name, argv[1], IFNAMSIZ-1);
-	ifr.ifr_name[IFNAMSIZ-1] = '\0';
+	strncpy(ifr.ifr_name, argv[1], IFNAMSIZ - 1);
+	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
 	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
 	if (!ifr.ifr_ifindex) {
 		perror("if_nametoindex");

--- a/cansend.c
+++ b/cansend.c
@@ -94,13 +94,14 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	addr.can_family = AF_CAN;
-
-	strcpy(ifr.ifr_name, argv[1]);
-	if (ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
-		perror("SIOCGIFINDEX");
+	strncpy(ifr.ifr_name, argv[1], IFNAMSIZ);
+	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+	if (!ifr.ifr_ifindex) {
+		perror("if_nametoindex");
 		return 1;
 	}
+
+	addr.can_family = AF_CAN;
 	addr.can_ifindex = ifr.ifr_ifindex;
 
 	if (required_mtu > CAN_MTU) {

--- a/cansend.c
+++ b/cansend.c
@@ -94,7 +94,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	strncpy(ifr.ifr_name, argv[1], IFNAMSIZ);
+	strncpy(ifr.ifr_name, argv[1], IFNAMSIZ-1);
+	ifr.ifr_name[IFNAMSIZ-1] = '\0';
 	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
 	if (!ifr.ifr_ifindex) {
 		perror("if_nametoindex");

--- a/isotpdump.c
+++ b/isotpdump.c
@@ -96,8 +96,6 @@ int main(int argc, char **argv)
 	int timestamp = 0;
 	int datidx = 0;
 	unsigned long fflen = 0;
-	struct ifreq ifr;
-	int ifindex;
 	struct timeval tv, last_tv;
 	unsigned int n_pci;
 	int opt;
@@ -202,12 +200,8 @@ int main(int argc, char **argv)
 
 	setsockopt(s, SOL_CAN_RAW, CAN_RAW_FILTER, &rfilter, sizeof(rfilter));
 
-	strcpy(ifr.ifr_name, argv[optind]);
-	ioctl(s, SIOCGIFINDEX, &ifr);
-	ifindex = ifr.ifr_ifindex;
-
 	addr.can_family = AF_CAN;
-	addr.can_ifindex = ifindex;
+	addr.can_ifindex = if_nametoindex(argv[optind]);
 
 	if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		perror("bind");

--- a/isotprecv.c
+++ b/isotprecv.c
@@ -81,7 +81,6 @@ int main(int argc, char **argv)
 {
     int s;
     struct sockaddr_can addr;
-    struct ifreq ifr;
     static struct can_isotp_options opts;
     static struct can_isotp_fc_options fcopts;
     static struct can_isotp_ll_options llopts;
@@ -232,9 +231,7 @@ int main(int argc, char **argv)
 	    setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_RX_STMIN, &force_rx_stmin, sizeof(force_rx_stmin));
 
     addr.can_family = AF_CAN;
-    strcpy(ifr.ifr_name, argv[optind]);
-    ioctl(s, SIOCGIFINDEX, &ifr);
-    addr.can_ifindex = ifr.ifr_ifindex;
+    addr.can_ifindex = if_nametoindex(argv[optind]);
 
     if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 	perror("bind");

--- a/isotpsend.c
+++ b/isotpsend.c
@@ -79,7 +79,6 @@ int main(int argc, char **argv)
 {
     int s;
     struct sockaddr_can addr;
-    struct ifreq ifr;
     static struct can_isotp_options opts;
     static struct can_isotp_ll_options llopts;
     int opt;
@@ -224,9 +223,7 @@ int main(int argc, char **argv)
 	    setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_TX_STMIN, &force_tx_stmin, sizeof(force_tx_stmin));
 
     addr.can_family = AF_CAN;
-    strcpy(ifr.ifr_name, argv[optind]);
-    ioctl(s, SIOCGIFINDEX, &ifr);
-    addr.can_ifindex = ifr.ifr_ifindex;
+    addr.can_ifindex = if_nametoindex(argv[optind]);
 
     if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 	perror("bind");

--- a/isotpserver.c
+++ b/isotpserver.c
@@ -137,7 +137,6 @@ int main(int argc, char **argv)
 	static struct can_isotp_options opts;
 	static struct can_isotp_fc_options fcopts;
 	static struct can_isotp_ll_options llopts;
-	struct ifreq ifr;
 	socklen_t sin_size = sizeof(clientaddr);
 	socklen_t caddrlen = sizeof(caddr);
 

--- a/isotpserver.c
+++ b/isotpserver.c
@@ -345,12 +345,7 @@ int main(int argc, char **argv)
 	}
 
 	caddr.can_family = AF_CAN;
-	strcpy(ifr.ifr_name, argv[optind]);
-	if (ioctl(sc, SIOCGIFINDEX, &ifr) < 0) {
-		perror("SIOCGIFINDEX");
-		exit(1);
-	}
-	caddr.can_ifindex = ifr.ifr_ifindex;
+	caddr.can_ifindex = if_nametoindex(argv[optind]);
 
 	if (bind(sc, (struct sockaddr *)&caddr, caddrlen) < 0) {
 		perror("bind");

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -271,9 +271,14 @@ int main(int argc, char **argv)
 
 	opts.flags |= CAN_ISOTP_LISTEN_MODE;
 
+	strncpy(ifr.ifr_name, argv[optind], IFNAMSIZ);
+	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+	if (!ifr.ifr_ifindex) {
+		perror("if_nametoindex");
+		return 1;
+	}
+
 	addr.can_family = AF_CAN;
-	strcpy(ifr.ifr_name, argv[optind]);
-	ioctl(s, SIOCGIFINDEX, &ifr);
 	addr.can_ifindex = ifr.ifr_ifindex;
 
 	setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts));

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -271,8 +271,8 @@ int main(int argc, char **argv)
 
 	opts.flags |= CAN_ISOTP_LISTEN_MODE;
 
-	strncpy(if_name, argv[optind], IFNAMSIZ-1);
-	if_name[IFNAMSIZ-1] = '\0';
+	strncpy(if_name, argv[optind], IFNAMSIZ - 1);
+	if_name[IFNAMSIZ - 1] = '\0';
 
 	addr.can_family = AF_CAN;
 	addr.can_ifindex = if_nametoindex(if_name);

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
 	fd_set rdfs;
 	int s, t;
 	struct sockaddr_can addr;
-	struct ifreq ifr;
+	char if_name[IFNAMSIZ];
 	static struct can_isotp_options opts;
 	int opt, quit = 0;
 	int color = 0;
@@ -271,15 +271,11 @@ int main(int argc, char **argv)
 
 	opts.flags |= CAN_ISOTP_LISTEN_MODE;
 
-	strncpy(ifr.ifr_name, argv[optind], IFNAMSIZ);
-	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
-	if (!ifr.ifr_ifindex) {
-		perror("if_nametoindex");
-		return 1;
-	}
+	strncpy(if_name, argv[optind], IFNAMSIZ-1);
+	if_name[IFNAMSIZ-1] = '\0';
 
 	addr.can_family = AF_CAN;
-	addr.can_ifindex = ifr.ifr_ifindex;
+	addr.can_ifindex = if_nametoindex(if_name);
 
 	setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts));
 
@@ -339,7 +335,7 @@ int main(int argc, char **argv)
 			if (nbytes > 4095)
 				return -1;
 			printbuf(buffer, nbytes, color?2:0, timestamp, format,
-				 &tv, &last_tv, dst, s, ifr.ifr_name, head);
+				 &tv, &last_tv, dst, s, if_name, head);
 		}
 
 		if (FD_ISSET(t, &rdfs)) {
@@ -351,7 +347,7 @@ int main(int argc, char **argv)
 			if (nbytes > 4095)
 				return -1;
 			printbuf(buffer, nbytes, color?1:0, timestamp, format,
-				 &tv, &last_tv, src, t, ifr.ifr_name, head);
+				 &tv, &last_tv, src, t, if_name, head);
 		}
 	}
 

--- a/isotptun.c
+++ b/isotptun.c
@@ -291,7 +291,8 @@ int main(int argc, char **argv)
 
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
-	strncpy(ifr.ifr_name, name, IFNAMSIZ);
+	strncpy(ifr.ifr_name, name, IFNAMSIZ-1);
+	ifr.ifr_name[IFNAMSIZ-1] = '\0';
 
 	if (ioctl(t, TUNSETIFF, (void *) &ifr) < 0) {
 		perror("ioctl tunfd");

--- a/isotptun.c
+++ b/isotptun.c
@@ -291,8 +291,8 @@ int main(int argc, char **argv)
 
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
-	strncpy(ifr.ifr_name, name, IFNAMSIZ-1);
-	ifr.ifr_name[IFNAMSIZ-1] = '\0';
+	strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
 
 	if (ioctl(t, TUNSETIFF, (void *) &ifr) < 0) {
 		perror("ioctl tunfd");

--- a/isotptun.c
+++ b/isotptun.c
@@ -265,9 +265,15 @@ int main(int argc, char **argv)
 		}
 	}
 
+	strncpy(ifr.ifr_name, argv[optind], IFNAMSIZ);
+	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
+	if (!ifr.ifr_ifindex) {
+		perror("if_nametoindex");
+		close(s);
+		exit(1);
+	}
+
 	addr.can_family = AF_CAN;
-	strcpy(ifr.ifr_name, argv[optind]);
-	ioctl(s, SIOCGIFINDEX, &ifr);
 	addr.can_ifindex = ifr.ifr_ifindex;
 
 	if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {

--- a/slcanpty.c
+++ b/slcanpty.c
@@ -415,7 +415,6 @@ int main(int argc, char **argv)
 	int s; /* can raw socket */ 
 	struct sockaddr_can addr;
 	struct termios topts;
-	struct ifreq ifr;
 	int select_stdin = 0;
 	int running = 1;
 	int tstamp = 0;
@@ -490,13 +489,7 @@ int main(int argc, char **argv)
 	}
 
 	addr.can_family = AF_CAN;
-
-	strcpy(ifr.ifr_name, argv[2]);
-	if (ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
-		perror("SIOCGIFINDEX");
-		return 1;
-	}
-	addr.can_ifindex = ifr.ifr_ifindex;
+	addr.can_ifindex = if_nametoindex(argv[2]);
 
 	/* disable reception of CAN frames until we are opened by 'O' */
 	setsockopt(s, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);


### PR DESCRIPTION
Replaced strcpy(if_name, argv[x])+ioctl by if_idx=if_nametoindex(argv[x]) to avoid overflows caused by long user input.

Signed-off-by: Sven Schmitt <sven.schmitt@gmx.net>