### PR TITLE
slcan: added listen-only flag

### DIFF
--- a/slcan_attach.c
+++ b/slcan_attach.c
@@ -58,6 +58,7 @@ void print_usage(char *prg)
 {
 	fprintf(stderr, "\nUsage: %s [options] tty\n\n", prg);
 	fprintf(stderr, "Options: -o         (send open command 'O\\r')\n");
+	fprintf(stderr, "         -l         (send listen only command 'L\\r', overrides -o)\n");
 	fprintf(stderr, "         -c         (send close command 'C\\r')\n");
 	fprintf(stderr, "         -f         (read status flags with 'F\\r' to reset error states)\n");
 	fprintf(stderr, "         -s <speed> (set CAN speed 0..8)\n");
@@ -81,6 +82,7 @@ int main(int argc, char **argv)
 	int detach = 0;
 	int waitkey = 0;
 	int send_open = 0;
+	int send_listen = 0;
 	int send_close = 0;
 	int send_read_status_flags = 0;
 	char *speed = NULL;
@@ -90,10 +92,10 @@ int main(int argc, char **argv)
 	char *name = NULL;
 	int opt;
 
-	while ((opt = getopt(argc, argv, "l:dwocfs:b:n:?")) != -1) {
+	while ((opt = getopt(argc, argv, "ldwocfs:b:n:?")) != -1) {
 		switch (opt) {
 		case 'l':
-			fprintf(stderr, "Ignored option '-l'\n");
+			send_listen = 1;
 			break;
 
 		case 'd':
@@ -168,7 +170,12 @@ int main(int argc, char **argv)
 			write(fd, buf, strlen(buf));
 		}
 
-		if (send_open) {
+		/* prefer listen-only over normal open */
+		if (send_listen) {
+			sprintf(buf, "L\r");
+			write(fd, buf, strlen(buf));
+
+		} else if (send_open) {
 			sprintf(buf, "O\r");
 			write(fd, buf, strlen(buf));
 		}

--- a/slcan_attach.c
+++ b/slcan_attach.c
@@ -177,7 +177,6 @@ int main(int argc, char **argv)
 
 			if (send_open)
 				printf("ignoring -o, due to listen-only option -l\n");
-
 		} else if (send_open) {
 			sprintf(buf, "O\r");
 			write(fd, buf, strlen(buf));

--- a/slcan_attach.c
+++ b/slcan_attach.c
@@ -175,6 +175,9 @@ int main(int argc, char **argv)
 			sprintf(buf, "L\r");
 			write(fd, buf, strlen(buf));
 
+			if (send_open)
+				printf("ignoring -o, due to listen-only option -l\n");
+
 		} else if (send_open) {
 			sprintf(buf, "O\r");
 			write(fd, buf, strlen(buf));

--- a/slcan_attach.c
+++ b/slcan_attach.c
@@ -94,10 +94,6 @@ int main(int argc, char **argv)
 
 	while ((opt = getopt(argc, argv, "ldwocfs:b:n:?")) != -1) {
 		switch (opt) {
-		case 'l':
-			send_listen = 1;
-			break;
-
 		case 'd':
 			detach = 1;
 			break;
@@ -108,6 +104,10 @@ int main(int argc, char **argv)
 
 		case 'o':
 			send_open = 1;
+			break;
+
+		case 'l':
+			send_listen = 1;
 			break;
 
 		case 'c':
@@ -170,13 +170,9 @@ int main(int argc, char **argv)
 			write(fd, buf, strlen(buf));
 		}
 
-		/* prefer listen-only over normal open */
 		if (send_listen) {
 			sprintf(buf, "L\r");
 			write(fd, buf, strlen(buf));
-
-			if (send_open)
-				printf("ignoring -o, due to listen-only option -l\n");
 		} else if (send_open) {
 			sprintf(buf, "O\r");
 			write(fd, buf, strlen(buf));


### PR DESCRIPTION
slcan_attach: use -l flag to send a L\r instead of O\r to use the can adapters listen-only mode