### PR TITLE
canfdtest: remove usage of gettimeofday

### DIFF
--- a/canfdtest.c
+++ b/canfdtest.c
@@ -120,21 +120,18 @@ static void compare_frame(struct can_frame *exp, struct can_frame *rec)
 
 static void millisleep(int msecs)
 {
-	if (msecs <= 0) {
-		sched_yield();
-	} else {
-		struct timespec rqtp, rmtp;
+	struct timespec rqtp, rmtp;
 
-		/* sleep in ms */
-		rqtp.tv_sec = msecs / 1000;
-		rqtp.tv_nsec = (msecs % 1000) * 1000000;
-		while (nanosleep(&rqtp, &rmtp)) {
-			if (errno != EINTR) {
-				printf("t\n");
-				break;
-			}
-			rqtp = rmtp;
+	/* sleep in ms */
+	rqtp.tv_sec = msecs / 1000;
+	rqtp.tv_nsec = msecs % 1000 * 1000000;
+
+	while (clock_nanosleep(CLOCK_MONOTONIC, 0, &rqtp, &rmtp)) {
+		if (errno != EINTR) {
+			printf("t\n");
+			break;
 		}
+		rqtp = rmtp;
 	}
 }
 
@@ -194,7 +191,6 @@ static int send_frame(struct can_frame *frame)
 static int can_echo_dut(void)
 {
 	unsigned int frame_count = 0;
-	struct timeval tvn, tv_stop;
 	struct can_frame frame;
 	int i;
 
@@ -227,22 +223,7 @@ static int can_echo_dut(void)
 		 */
 		if (frame_count == CAN_MSG_WAIT) {
 			frame_count = 0;
-			if (gettimeofday(&tv_stop, NULL)) {
-				perror("gettimeofday failed\n");
-				return -1;
-			} else {
-				tv_stop.tv_usec += 3000;
-				if (tv_stop.tv_usec > 999999) {
-					tv_stop.tv_sec++;
-					tv_stop.tv_usec =
-						tv_stop.tv_usec % 1000000;
-				}
-				gettimeofday(&tvn, NULL);
-				while ((tv_stop.tv_sec > tvn.tv_sec) ||
-				       ((tv_stop.tv_sec == tvn.tv_sec) &&
-					(tv_stop.tv_usec >= tvn.tv_usec)))
-					gettimeofday(&tvn, NULL);
-			}
+			millisleep(3);
 		}
 	}
 


### PR DESCRIPTION
This patch fixes the issue #13

https://github.com/linux-can/can-utils/issues/13

Modified the existing millisleep function to use MONOTONIC clock & used
clock_nanosleep with absolute timeout to be accurate. Also cleaned up unused
variables in can_echo_dut.

Signed-off-by: Ramesh Shanmugasundaram ramesh.shanmugasundaram@bp.renesas.com
