### PR TITLE
cangen: reset frame flags at the start of iteration

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -357,6 +357,7 @@ int main(int argc, char **argv)
 	}
 
 	while (running) {
+		frame.flags = 0;
 
 		if (count && (--count == 0))
 			running = 0;


### PR DESCRIPTION
This patch fixes a bug in cangen.c

Bug: When used with -m option, if a CAN FD frame with BRS option set is
sent, that flag never gets cleared for the subsequent frames.

Fix: Reset frame.flags at the start of iteration.

Signed-off-by: Ramesh Shanmugasundaram <ramesh.shanmugasundaram@bp.renesas.com>