### PR TITLE
header-guard for lib.h

### DIFF
--- a/lib.h
+++ b/lib.h
@@ -41,6 +41,11 @@
  *
  */
 
+#ifndef CAN_UTILS_LIB_H
+#define CAN_UTILS_LIB_H
+
+#include <stdio.h>
+
 /* buffer sizes for CAN frame string representations */
 
 #define CL_ID (sizeof("12345678##1"))
@@ -208,3 +213,5 @@ void snprintf_can_error_frame(char *buf, size_t len, const struct canfd_frame *c
 /*
  * Creates a CAN error frame output in user readable format.
  */
+
+#endif


### PR DESCRIPTION
Ah... I was trying to include lib.h from 2 different headers and ... just noticed...

A header guard would be nice as well. Also including `stdio.h` to handle `FILE` ([ref](https://github.com/linux-can/can-utils/blob/ef2ea8fa59e9123c496a109b2b4cb62dd1e3e7fa/lib.h#L145))

(Thanks for quick previous merge.)