### PR TITLE
Add check to detect clock_nanosleep() in librt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,8 @@ AC_CHECK_FUNCS([ \
 	strtoul \
 ])
 
+# glibc versions before 2.17 needs to link with -lrt for clock_nanosleep
+AC_SEARCH_LIBS([clock_nanosleep], [rt])
 
 AC_CHECK_DECL(SO_RXQ_OVFL,,
     [AC_DEFINE([SO_RXQ_OVFL], [40], [SO_RXQ_OVFL])]


### PR DESCRIPTION
With glibc versions before 2.17, we get following build error:

  canfdtest.o: In function `millisleep':
  canfdtest.c:(.text+0x212): undefined reference to `clock_nanosleep'
  collect2: error: ld returned 1 exit status
  make[1]: *** [canfdtest] Error 1
  make[1]: *** Waiting for unfinished jobs....

glibc versions before 2.17 needs to link with -lrt for
clock_nanosleep(). This patch adds support to detect if linking with
librt is required.

This build issue is detected by Buildroot autobuilder:
http://autobuild.buildroot.net/results/0e5/0e5242376ff6aa82e89ed1172350e05009d48156/build-end.log

Signed-off-by: Rahul Bedarkar <rahul.bedarkar@imgtec.com>