### PR TITLE
isotptun: daemonize by default, add -F for old behavior

### DIFF
--- a/isotptun.c
+++ b/isotptun.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 			else if (elements == 2)
 				opts.flags |= (CAN_ISOTP_EXTEND_ADDR | CAN_ISOTP_RX_EXT_ADDR);
 			else {
-				printf("incorrect extended addr values '%s'.\n", optarg);
+				fprintf(stderr, "incorrect extended addr values '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
 				exit(EXIT_FAILURE);
 			}
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
 			else if (sscanf(optarg, ":%hhx", &opts.rxpad_content) == 1)
 				opts.flags |= CAN_ISOTP_RX_PADDING;
 			else {
-				printf("incorrect padding values '%s'.\n", optarg);
+				fprintf(stderr, "incorrect padding values '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
 				exit(EXIT_FAILURE);
 			}
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
 			else if (optarg[0] == 'a')
 				opts.flags |= (CAN_ISOTP_CHK_PAD_LEN | CAN_ISOTP_CHK_PAD_DATA);
 			else {
-				printf("unknown padding check option '%c'.\n", optarg[0]);
+				fprintf(stderr, "unknown padding check option '%c'.\n", optarg[0]);
 				print_usage(basename(argv[0]));
 				exit(EXIT_FAILURE);
 			}
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
 				   &llopts.mtu,
 				   &llopts.tx_dl,
 				   &llopts.tx_flags) != 3) {
-				printf("unknown link layer options '%s'.\n", optarg);
+				fprintf(stderr, "unknown link layer options '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
 				exit(EXIT_FAILURE);
 			}

--- a/isotptun.c
+++ b/isotptun.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 			else {
 				printf("incorrect extended addr values '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
-				exit(0);
+				exit(EXIT_FAILURE);
 			}
 			break;
 		}
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
 			else {
 				printf("incorrect padding values '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
-				exit(0);
+				exit(EXIT_FAILURE);
 			}
 			break;
 		}
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 			else {
 				printf("unknown padding check option '%c'.\n", optarg[0]);
 				print_usage(basename(argv[0]));
-				exit(0);
+				exit(EXIT_FAILURE);
 			}
 			break;
 
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
 				   &llopts.tx_flags) != 3) {
 				printf("unknown link layer options '%s'.\n", optarg);
 				print_usage(basename(argv[0]));
-				exit(0);
+				exit(EXIT_FAILURE);
 			}
 			break;
 
@@ -232,13 +232,13 @@ int main(int argc, char **argv)
 
 		case '?':
 			print_usage(basename(argv[0]));
-			exit(0);
+			exit(EXIT_SUCCESS);
 			break;
 
 		default:
 			fprintf(stderr, "Unknown option %c\n", opt);
 			print_usage(basename(argv[0]));
-			exit(1);
+			exit(EXIT_FAILURE);
 			break;
 		}
 	}
@@ -247,12 +247,12 @@ int main(int argc, char **argv)
 	    (addr.can_addr.tp.tx_id == NO_CAN_ID) ||
 	    (addr.can_addr.tp.rx_id == NO_CAN_ID)) {
 		print_usage(basename(argv[0]));
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
   
 	if ((s = socket(PF_CAN, SOCK_DGRAM, CAN_ISOTP)) < 0) {
 		perror("socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_OPTS, &opts, sizeof(opts));
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
 	if (llopts.tx_dl) {
 		if (setsockopt(s, SOL_CAN_ISOTP, CAN_ISOTP_LL_OPTS, &llopts, sizeof(llopts)) < 0) {
 			perror("link layer sockopt");
-			exit(1);
+			exit(EXIT_FAILURE);
 		}
 	}
 
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
 	if (!ifr.ifr_ifindex) {
 		perror("if_nametoindex");
 		close(s);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	addr.can_family = AF_CAN;
@@ -279,14 +279,14 @@ int main(int argc, char **argv)
 	if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		perror("bind");
 		close(s);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	if ((t = open("/dev/net/tun", O_RDWR)) < 0) {
 		perror("open tunfd");
 		close(s);
 		close(t);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	memset(&ifr, 0, sizeof(ifr));
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
 		perror("ioctl tunfd");
 		close(s);
 		close(t);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	while (running) {
@@ -351,5 +351,5 @@ int main(int argc, char **argv)
 
 	close(s);
 	close(t);
-	return 0;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
We want isotptun to exit when the tun device can be used. This helps system
startup continue configuration and use of the interface at correct time.

Log errors to syslog when daemonized or to stderr when in foreground.

Exit consistently with EXIT_FAILURE when the tun device was not set up as
defined on the command line.

Signed-off-by: Marko Kohtala <marko.kohtala@gmail.com>