### PR TITLE
use a macro for standardization

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -69,7 +69,7 @@ static inline void _put_id(char *buf, int end_offset, canid_t id)
 {
 	/* build 3 (SFF) or 8 (EFF) digit CAN identifier */
 	while (end_offset >= 0) {
-		buf[end_offset--] = hex_asc_upper[id & 0xF];
+		buf[end_offset--] = hex_asc_upper_lo(id);
 		id >>= 4;
 	}
 }

--- a/lib.c
+++ b/lib.c
@@ -463,7 +463,7 @@ static const char *protocol_violation_types[] = {
 static const char *protocol_violation_locations[] = {
 	"unspecified",
 	"unspecified",
-	"id.28-to-id.28",
+	"id.28-to-id.21",
 	"start-of-frame",
 	"bit-srtr",
 	"bit-ide",


### PR DESCRIPTION
I was reading the code to learn more about can but I noticed that the hex_asc_upper_lo macro which is defined before do the same thing as  hex_asc_upper[id & 0xF] so it needs to change for standardization