### PR TITLE
increase TTYPATH_LENGTH

### DIFF
--- a/slcand.c
+++ b/slcand.c
@@ -48,7 +48,7 @@
 #define RUN_AS_USER "root"
 
 /* The length of ttypath buffer */
-#define TTYPATH_LENGTH	64
+#define TTYPATH_LENGTH	256
 
 /* UART flow control types */
 #define FLOW_NONE 0


### PR DESCRIPTION
ttypath can't fit filenames such as /dev/serial/by-id/usb-Zubax_Robotics_Zubax_Babel_1D002A00185732523935382000000000-if00