### PR TITLE
Add option to read hardware timestamps.

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -568,7 +568,7 @@ int main(int argc, char **argv)
 			int timestamping_flags = 1;
 			if (hwtimestamp) {
 				timestamping_flags = SOF_TIMESTAMPING_SOFTWARE | SOF_TIMESTAMPING_RX_SOFTWARE | \
-						SOF_TIMESTAMPING_RAW_HARDWARE | SOF_TIMESTAMPING_SYS_HARDWARE;
+						SOF_TIMESTAMPING_RAW_HARDWARE;
 				if (setsockopt(s[i], SOL_SOCKET, SO_TIMESTAMPING,
 						&timestamping_flags, sizeof(timestamping_flags)) < 0) {
 					perror("setsockopt SO_TIMESTAMPING");

--- a/candump.c
+++ b/candump.c
@@ -713,11 +713,13 @@ int main(int argc, char **argv)
 
 						struct timespec *stamp = (struct timespec *)CMSG_DATA(cmsg);
 
-						stamp += 2;
-						tv.tv_sec = stamp->tv_sec;
-						tv.tv_usec = stamp->tv_nsec/1000;
-					}
-					else if (cmsg->cmsg_type == SO_RXQ_OVFL)
+						// stamp[0] is the software timestamp
+						// stamp[1] is deprecated
+						// stamp[2] is the raw hardware timestamp
+						// See 2.1.2 in doc/Documentation/networking/timestamping.txt
+						tv.tv_sec = stamp[2].tv_sec;
+						tv.tv_usec = stamp[2].tv_nsec/1000;
+					} else if (cmsg->cmsg_type == SO_RXQ_OVFL)
 						memcpy(&dropcnt[i], CMSG_DATA(cmsg), sizeof(__u32));
 				}
 


### PR DESCRIPTION
I took the code from https://marc.info/?l=linux-can&m=138244457221323&w=2.

Unfortunately only the pcan driver provides hardware timestamps.

Note that I don't own a PCAN adapter, I tested this modification using a self made pcan compatible adapter, receiving one message every 400 us and the hardware timestamp sometimes jumps back or forward. The same self made adapter gives correct timestamps in Windows with the official driver and PCAN-view.