### PR TITLE
Android.mk: Allow building in AOSP source tree

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,7 +3,11 @@ LOCAL_PATH := $(call my-dir)
 PRIVATE_LOCAL_CFLAGS := -O2 -g -W -Wall		\
 			-DSO_RXQ_OVFL=40	\
 			-DPF_CAN=29		\
-			-DAF_CAN=PF_CAN
+			-DAF_CAN=PF_CAN \
+			-Wno-error=unused-parameter \
+			-Wno-error=sign-compare \
+			-Wno-error=pointer-arith \
+			-Wno-error=address-of-packed-member
 
 #
 # canlib


### PR DESCRIPTION
AOSP is treating all warnings as errors. Allow these specific warnings through.
Fixes #61 