### PR TITLE
testj1939: use address to string function from libj1939

### DIFF
--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -69,6 +69,7 @@ bin_PROGRAMS = \
 jacd_LDADD = libj1939.la
 jspy_LDADD = libj1939.la
 jsr_LDADD = libj1939.la
+testj1939_LDADD = libj1939.la
 
 EXTRA_DIST = \
 	.travis.yml \

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ log2asc.o:	lib.h
 asc2log.o:	lib.h
 jspy.o:		libj1939.h
 jsr.o:		libj1939.h
+testj1939.o:	libj1939.h
 canframelen.o:  canframelen.h
 
 cansend:	cansend.o	lib.o
@@ -102,3 +103,4 @@ canbusload:	canbusload.o	canframelen.o
 
 jspy:		jspy.o		libj1939.o
 jsr:		jsr.o		libj1939.o
+testj1939:	testj1939.o	libj1939.o


### PR DESCRIPTION
canaddr2str() from testj1939 and libj1939's libj1939_addr2str provide
the same functionality. Remove the local helper function and use
libj1939_addr2str instead.

Signed-off-by: Bastian Stender <bst@pengutronix.de>