### PR TITLE
bzero() is deprecated

### DIFF
--- a/cansend.c
+++ b/cansend.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	bzero(&addr,sizeof(struct sockaddr_can));
+	memset(&addr, 0, sizeof(addr));
 	addr.can_family = AF_CAN;
 	addr.can_ifindex = ifr.ifr_ifindex;
 


### PR DESCRIPTION
Use memset() instead of bzero().