### PR TITLE
Consistent arguments to sizeof().

### DIFF
--- a/canbusload.c
+++ b/canbusload.c
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
 
 			if (FD_ISSET(s[i], &rdfs)) {
 
-				nbytes = read(s[i], &frame, sizeof(struct can_frame));
+				nbytes = read(s[i], &frame, sizeof(frame));
 
 				if (nbytes < 0) {
 					perror("read");

--- a/slcand.c
+++ b/slcand.c
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Configure baud rate */
-	memset(&tios, 0, sizeof(struct termios));
+	memset(&tios, 0, sizeof(tios));
 	if (tcgetattr(fd, &tios) < 0) {
 		syslogger(LOG_NOTICE, "failed to get attributes for TTY device %s: %s\n", ttypath, strerror(errno));
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
In calls to functions taking a pointer 'p' and a length 'l':
if the address of a struct variable v is passed in for p, then also pass sizeof(v) for
l.