### PR TITLE
Revert "Fix CAN ID typo in candump usage, to 12345678"

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -152,7 +152,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "%s -c -c -ta can0,123:7FF,400:700,#000000FF can2,400~7F0 can3 can8\n", prg);
 	fprintf(stderr, "%s -l any,0~0,#FFFFFFFF    (log only error frames but no(!) data frames)\n", prg);
 	fprintf(stderr, "%s -l any,0:0,#FFFFFFFF    (log error frames and also all data frames)\n", prg);
-	fprintf(stderr, "%s vcan2,12345678:DFFFFFFF (match only for extended CAN ID 12345678)\n", prg);
+	fprintf(stderr, "%s vcan2,92345678:DFFFFFFF (match only for extended CAN ID 12345678)\n", prg);
 	fprintf(stderr, "%s vcan2,123:7FF (matches CAN ID 123 - including EFF and RTR frames)\n", prg);
 	fprintf(stderr, "%s vcan2,123:C00007FF (matches CAN ID 123 - only SFF and non-RTR frames)\n", prg);
 	fprintf(stderr, "\n");

--- a/candump.c
+++ b/candump.c
@@ -147,6 +147,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "\nCAN IDs, masks and data content are given and expected in hexadecimal values.\n");
 	fprintf(stderr, "When can_id and can_mask are both 8 digits, they are assumed to be 29 bit EFF.\n");
 	fprintf(stderr, "Without any given filter all data frames are received ('0:0' default filter).\n");
+	fprintf(stderr, "The filter value is directly passed to the SocketCAN interface, and must set CAN_EFF_FLAG (0x80000000) correctly.");
 	fprintf(stderr, "\nUse interface name '%s' to receive from all CAN interfaces.\n", ANYDEV);
 	fprintf(stderr, "\nExamples:\n");
 	fprintf(stderr, "%s -c -c -ta can0,123:7FF,400:700,#000000FF can2,400~7F0 can3 can8\n", prg);

--- a/candump.c
+++ b/candump.c
@@ -147,7 +147,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "\nCAN IDs, masks and data content are given and expected in hexadecimal values.\n");
 	fprintf(stderr, "When can_id and can_mask are both 8 digits, they are assumed to be 29 bit EFF.\n");
 	fprintf(stderr, "Without any given filter all data frames are received ('0:0' default filter).\n");
-	fprintf(stderr, "The filter value is directly passed to the SocketCAN interface, and must set CAN_EFF_FLAG (0x80000000) correctly.");
+	fprintf(stderr, "The filter value is directly passed to the SocketCAN interface, and must set CAN_EFF_FLAG (0x80000000) correctly.\n");
 	fprintf(stderr, "\nUse interface name '%s' to receive from all CAN interfaces.\n", ANYDEV);
 	fprintf(stderr, "\nExamples:\n");
 	fprintf(stderr, "%s -c -c -ta can0,123:7FF,400:700,#000000FF can2,400~7F0 can3 can8\n", prg);


### PR DESCRIPTION
Reverts linux-can/can-utils#108

The documentation was correct - the MSB in the CAN ID and mask must be set. My mistake. Thank you @hartkopp !

(I think this is the extended ID bit?)