### PR TITLE
Don't build libj1939 for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,15 +63,15 @@ set(PROGRAMS
 
 if(NOT ANDROID)
   list(APPEND PROGRAMS ${PROGRAMS_J1939})
+
+  add_library(j1939 STATIC
+      libj1939.c
+  )
 endif()
 
 add_library(can STATIC
     lib.c
     canframelen.c
-)
-
-add_library(j1939 STATIC
-    libj1939.c
 )
 
 foreach(name ${PROGRAMS})


### PR DESCRIPTION
This library uses `if_nameindex` symbol, not available at this system.

When compiling for Android, you get the following warnings:
```
libj1939.c:35:3: warning: implicit declaration of function 'if_freenameindex' is invalid in C99 [-Wimplicit-function-declaration]
libj1939.c:42:11: warning: implicit declaration of function 'if_nameindex' is invalid in C99 [-Wimplicit-function-declaration]
libj1939.c:42:9: warning: incompatible integer to pointer conversion assigning to 'struct if_nameindex *' from 'int' [-Wint-conversion]
libj1939.c:44:4: warning: implicit declaration of function 'error' is invalid in C99 [-Wimplicit-function-declaration]
```
