### PR TITLE
testj1939: fail if we use unsupported size

### DIFF
--- a/testj1939.c
+++ b/testj1939.c
@@ -101,6 +101,8 @@ int main(int argc, char *argv[])
 		break;
 	case 's':
 		todo_send = strtoul(optarg ?: "8", NULL, 0);
+		if (todo_send > sizeof(dat))
+			error(1, 0, "Unsupported size. max: %i", sizeof(dat));
 		break;
 	case 'r':
 		todo_recv = 1;


### PR DESCRIPTION
Currently if we set size which is more then 128 byte
will silently ignore provided value and send only maximal
supported size.

Signed-off-by: Oleksij Rempel <o.rempel@pengutronix.de>