### PR TITLE
testj1939: split output string in to 8 byte strings

### DIFF
--- a/testj1939.c
+++ b/testj1939.c
@@ -257,12 +257,19 @@ int main(int argc, char *argv[])
 				error(1, errno, "sendto");
 		}
 		if (todo_recv) {
+			int i = 0;
+
 			if (todo_names && peername.can_addr.j1939.name)
 				printf("%016llx ", peername.can_addr.j1939.name);
 			printf("%02x %05x:", peername.can_addr.j1939.addr,
 					peername.can_addr.j1939.pgn);
-			for (j = 0; j < ret; ++j)
+			for (j = 0; j < ret; ++j, i++) {
+				if (i == 8) {
+					printf("\n%05x    ", j);
+					i = 0;
+				}
 				printf(" %02x", dat[j]);
+			}
 			printf("\n");
 		}
 	}


### PR DESCRIPTION
Currently if we send lots of bytes, `test1939` output will get unreadable.
Make it easier to read by splitting output dump.
New format will looks as following example:
```
root@DistroKit:~ testj1939 can0:0x90 -r
80 12300: 01 23 45 67 89 ab cd ef
00008     01 23 45 67 89 ab cd ef
00010     01 23 45 67 89 ab cd ef
00018     01 23 45 67 89 ab cd ef
00020     01 23 45 67 89 ab cd ef
00028     01 23 45 67 89 ab cd ef
00030     01 23 45 67 89 ab cd ef
00038     01 23 45 67 89 ab cd ef
00040     01 23 45 67 89 ab cd ef
00048     01 23 45 67 89 ab cd ef
00050     01 23 45 67 89 ab cd ef
00058     01 23 45 67 89 ab cd ef
00060     01 23 45 67 89 ab cd ef
00068     01 23 45 67 89 ab cd ef
00070     01 23 45 67 89 ab cd ef
00078     01 23 45 67 89 ab cd ef
```

Signed-off-by: Oleksij Rempel <o.rempel@pengutronix.de>