### PR TITLE
testj1939: use %zu to as format string to print sizeof()

### DIFF
--- a/testj1939.c
+++ b/testj1939.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	case 's':
 		todo_send = strtoul(optarg ?: "8", NULL, 0);
 		if (todo_send > sizeof(dat))
-			error(1, 0, "Unsupported size. max: %i", sizeof(dat));
+			error(1, 0, "Unsupported size. max: %zu", sizeof(dat));
 		break;
 	case 'r':
 		todo_recv = 1;


### PR DESCRIPTION
This patch uses `%zu` to print the value of `sizeof()`. This works without compiler warnings on 32 and 64 bit systems.