### PR TITLE
j1939 : Allows to receive own frame.

### DIFF
--- a/testj1939.c
+++ b/testj1939.c
@@ -206,6 +206,18 @@ int main(int argc, char *argv[])
 			if (ret < 0)
 				error(1, errno, "re-bind()");
 		}
+
+
+		/*
+                 * Activate own and promisc
+                 */
+
+                int promisc = 1; /* 0 = disabled (default), 1 = enabled */
+                setsockopt(sock, SOL_CAN_J1939, SO_J1939_PROMISC, &promisc, sizeof(promisc));
+                int recv_own_msgs = 1; /* 0 = disabled (default), 1 = enabled */
+                setsockopt(sock, SOL_CAN_J1939, SO_J1939_RECV_OWN, &recv_own_msgs, sizeof(recv_own_msgs));
+
+
 	}
 
 	if (todo_connect) {


### PR DESCRIPTION
Need this patch after commit on kernel.org 	:
dfa62204a6f5c8689431a21b23830a5929b373d1 j1939: socket: rework receive filter.

Signed-off-by: Arthur Guyader <arthur.guyader@iot.bzh>