### PR TITLE
fix include to find SIOCGSTAMP with latest kernel

### DIFF
--- a/canlogserver.c
+++ b/canlogserver.c
@@ -62,6 +62,7 @@
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#include <linux/sockios.h>
 #include <signal.h>
 #include <errno.h>
 

--- a/cansniffer.c
+++ b/cansniffer.c
@@ -62,6 +62,7 @@
 
 #include <linux/can.h>
 #include <linux/can/bcm.h>
+#include <linux/sockios.h>
 
 #include "terminal.h"
 

--- a/isotpdump.c
+++ b/isotpdump.c
@@ -57,6 +57,7 @@
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#include <linux/sockios.h>
 #include "terminal.h"
 
 #define NO_CAN_ID 0xFFFFFFFFU

--- a/isotpperf.c
+++ b/isotpperf.c
@@ -57,6 +57,7 @@
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#include <linux/sockios.h>
 
 #define NO_CAN_ID 0xFFFFFFFFU
 #define PERCENTRES 2 /* resolution in percent for bargraph */

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -56,6 +56,7 @@
 
 #include <linux/can.h>
 #include <linux/can/isotp.h>
+#include <linux/sockios.h>
 #include "terminal.h"
 
 #define NO_CAN_ID 0xFFFFFFFFU

--- a/slcanpty.c
+++ b/slcanpty.c
@@ -37,6 +37,7 @@
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#include <linux/sockios.h>
 
 /* maximum rx buffer len: extended CAN frame with timestamp */
 #define SLC_MTU (sizeof("T1111222281122334455667788EA5F\r")+1)


### PR DESCRIPTION
In linux kernel commit 0768e17073dc527ccd18ed5f96ce85f9985e9115
the asm-generic/sockios.h header no longer defines SIOCGSTAMP.
Instead it provides only SIOCGSTAMP_OLD.

The linux/sockios.h header now defines SIOCGSTAMP using either
SIOCGSTAMP_OLD or SIOCGSTAMP_NEW as appropriate. This linux only
header file is not pulled so we get a build failure.

canlogserver.c: In function 'main':
canlogserver.c:404:21: error: 'SIOCGSTAMP' undeclared (first use in this function); did you mean 'SIOCGRARP'?
     if (ioctl(s[i], SIOCGSTAMP, &tv) < 0)
                     ^~~~~~~~~~
                     SIOCGRARP
canlogserver.c:404:21: note: each undeclared identifier is reported only once for each function it appears in

Fixes:
 - http://autobuild.buildroot.org/results/363de7d9bf433be8bc47ba4ee52ae0bb80fa9021

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>