### PR TITLE
Fix spelling in various files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ subsystem (aka SocketCAN):
 * [cannelloni](https://github.com/mguentner/cannelloni) : UDP/SCTP based SocketCAN tunnel
 
 #### CAN in-kernel gateway configuration
-* cangw : CAN gateway userpace tool for netlink configuration
+* cangw : CAN gateway userspace tool for netlink configuration
 
 #### CAN bus measurement and testing
 * canbusload : calculate and display the CAN busload

--- a/bcmserver.c
+++ b/bcmserver.c
@@ -2,7 +2,7 @@
 /*
  * tst-bcm-server.c
  *
- * Test programm that implements a socket server which understands ASCII
+ * Test program that implements a socket server which understands ASCII
  * messages for simple broadcast manager frame send commands.
  *
  * < interface command ival_s ival_us can_id can_dlc [data]* >

--- a/can-j1939-kickstart.md
+++ b/can-j1939-kickstart.md
@@ -115,7 +115,7 @@ The destination field may be set during sendto().
 emits **19234080#0123456789ABCDEF** .
 
 The destination CAN iface __must__ always match the source CAN iface.
-Specifing one during bind is therefore sufficient.
+Specifying one during bind is therefore sufficient.
 
 	./testj1939 -s can0:,0x12300 :0x40
 
@@ -133,7 +133,7 @@ For broadcasted transmissions
 
 emits **1B21FF80#0123456789ABCDEF** rather than 1923FF80#012345678ABCDEF
 
-Desitination specific transmissions
+Destination specific transmissions
 
 	./testj1939 -s can0:0x80,0x12300 :0x40,0x32100
 
@@ -169,7 +169,7 @@ emits:
 	18EBFF80#02EF0123456789AB
 	18EBFF80#03CDEF01234567FF
 
-The fragments for broadcasted *Transport Protocol* are seperated
+The fragments for broadcasted *Transport Protocol* are separated
 __50ms__ from each other.
 Destination specific *Transport Protocol* applies flow control
 and may emit CAN packets much faster.

--- a/can-j1939.md
+++ b/can-j1939.md
@@ -19,7 +19,7 @@ See [Wikipedia:socketcan](http://en.wikipedia.org/wiki/Socketcan)
 * CAN id is composed of
   * 0..8: SA (source address)
   * 9..26:
-    * PDU1: PGN+DA (destionation address)
+    * PDU1: PGN+DA (destination address)
     * PDU2: PGN
   * 27..29: PRIO
 
@@ -61,7 +61,7 @@ will emit a single CAN frame.
 
 	send(sock, data, 9, 0);
 
-will use fragementation, emitting 1+ CAN frames.
+will use fragmentation, emitting 1+ CAN frames.
 
 # Using J1939
 

--- a/canbusload.c
+++ b/canbusload.c
@@ -103,7 +103,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "Up to %d CAN interfaces with mandatory bitrate can be specified on the \n", MAXSOCK);
 	fprintf(stderr, "commandline in the form: <ifname>@<bitrate>\n\n");
 	fprintf(stderr, "The bitrate is mandatory as it is needed to know the CAN bus bitrate to\n");
-	fprintf(stderr, "calcultate the bus load percentage based on the received CAN frames.\n");
+	fprintf(stderr, "calculate the bus load percentage based on the received CAN frames.\n");
 	fprintf(stderr, "Due to the bitstuffing estimation the calculated busload may exceed 100%%.\n");
 	fprintf(stderr, "For each given interface the data is presented in one line which contains:\n\n");
 	fprintf(stderr, "(interface) (received CAN frames) (used bits total) (used bits for payload)\n");

--- a/candump.c
+++ b/candump.c
@@ -130,7 +130,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -u <usecs>  (delay bridge forwarding by <usecs> microseconds)\n");
 	fprintf(stderr, "         -l          (log CAN-frames into file. Sets '-s %d' by default)\n", SILENT_ON);
 	fprintf(stderr, "         -L          (use log file format on stdout)\n");
-	fprintf(stderr, "         -n <count>  (terminate after receiption of <count> CAN frames)\n");
+	fprintf(stderr, "         -n <count>  (terminate after reception of <count> CAN frames)\n");
 	fprintf(stderr, "         -r <size>   (set socket receive buffer to <size>)\n");
 	fprintf(stderr, "         -D          (Don't exit if a \"detected\" can device goes down.\n");
 	fprintf(stderr, "         -d          (monitor dropped CAN frames)\n");

--- a/cangw.c
+++ b/cangw.c
@@ -467,7 +467,7 @@ int parse_fdmod(char *optarg, struct fdmodattr *modmsg)
 
 int parse_rtlist(char *prgname, unsigned char *rxbuf, int len)
 {
-	char ifname[IF_NAMESIZE]; /* internface name for if_indextoname() */
+	char ifname[IF_NAMESIZE]; /* interface name for if_indextoname() */
 	struct rtcanmsg *rtc;
 	struct rtattr *rta;
 	struct nlmsghdr *nlh;

--- a/canplayer.c
+++ b/canplayer.c
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
 	}
 
 	if (assignments) {
-		/* add & check user assginments from commandline */
+		/* add & check user assignments from commandline */
 		for (i=0; i<assignments; i++) {
 			if (strlen(argv[optind+i]) >= BUFSZ) {
 				fprintf(stderr, "Assignment too long!\n");

--- a/isotprecv.c
+++ b/isotprecv.c
@@ -71,7 +71,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -m <val>     (STmin in ms/ns. See spec.)\n");
 	fprintf(stderr, "         -f <time ns> (force rx stmin value in nanosecs)\n");
 	fprintf(stderr, "         -w <num>     (max. wait frame transmissions.)\n");
-	fprintf(stderr, "         -l           (loop: do not exit after pdu receiption.)\n");
+	fprintf(stderr, "         -l           (loop: do not exit after pdu reception.)\n");
 	fprintf(stderr, "         -L <mtu>:<tx_dl>:<tx_flags> (link layer options for CAN FD)\n");
 	fprintf(stderr, "\nCAN IDs and addresses are given and expected in hexadecimal values.\n");
 	fprintf(stderr, "The pdu data is written on STDOUT in space separated ASCII hex values.\n");

--- a/isotpserver.c
+++ b/isotpserver.c
@@ -102,10 +102,10 @@ void print_usage(char *prg)
 	fprintf(stderr, "\nUsage: %s -l <port> -s <can_id> -d <can_id> [options] <CAN interface>\n", prg);
 	fprintf(stderr, "Options: (* = mandatory)\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "ip adressing:\n");
+	fprintf(stderr, "ip addressing:\n");
 	fprintf(stderr, " *       -l <port>    (local port for the server)\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "isotp adressing:\n");
+	fprintf(stderr, "isotp addressing:\n");
 	fprintf(stderr, " *       -s <can_id>  (source can_id. Use 8 digits for extended IDs)\n");
 	fprintf(stderr, " *       -d <can_id>  (destination can_id. Use 8 digits for extended IDs)\n");
 	fprintf(stderr, "         -x <addr>[:<rxaddr>] (extended addressing / opt. separate rxaddr)\n");

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -137,7 +137,7 @@ void printbuf(unsigned char *buffer, int nbytes, int color, int timestamp,
 		}
 	}
 
-	/* the source socket gets pdu data from the detination id */
+	/* the source socket gets pdu data from the destination id */
 	printf(" %s  %03X  [%d]  ", candevice, src & CAN_EFF_MASK, nbytes);
 	if (format & FORMAT_HEX) {
 		for (i=0; i<nbytes; i++) {

--- a/jspy.c
+++ b/jspy.c
@@ -75,7 +75,7 @@ static struct {
 };
 
 /*
- * usefull buffers
+ * useful buffers
  */
 static const int ival_1 = 1;
 

--- a/lib.h
+++ b/lib.h
@@ -97,7 +97,7 @@ int hexstring2data(char *arg, unsigned char *data, int maxdlen);
 
 int parse_canframe(char *cs, struct canfd_frame *cf);
 /*
- * Transfers a valid ASCII string decribing a CAN frame into struct canfd_frame.
+ * Transfers a valid ASCII string describing a CAN frame into struct canfd_frame.
  *
  * CAN 2.0 frames
  * - string layout <can_id>#{R{len}|data}

--- a/slcanpty.c
+++ b/slcanpty.c
@@ -75,7 +75,7 @@ int pty2can(int pty, int socket, struct can_filter *fi,
 
 	nbytes = read(pty, &buf[rxoffset], sizeof(buf)-rxoffset-1);
 	if (nbytes <= 0) {
-		/* nbytes == 0 : no error but pty decriptor has been closed */
+		/* nbytes == 0 : no error but pty descriptor has been closed */
 		if (nbytes < 0)
 			perror("read pty");
 


### PR DESCRIPTION
codespell parameters:

`codespell -q 3 --skip="*.in,*.sh,*.m4,config,configure,autom4te.cache"`

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>