### PR TITLE
libj1939: fix missing include and syntax

### DIFF
--- a/libj1939.c
+++ b/libj1939.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
+#include <err.h>
 #include <inttypes.h>
 
 #include <unistd.h>
@@ -41,7 +41,7 @@ static inline void fetch_names(void)
 	if (!saved) {
 		saved = if_nameindex();
 		if (!saved)
-			err(1, errno, "if_nameindex()");
+			err(1, "if_nameindex()");
 	}
 }
 


### PR DESCRIPTION
Include err.h and remove the unneeded parameter errno and
its header include.

Fixes: 791b6de ("treewide: Fix compilation on libmusl, replace error() by err()")

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>