### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -1,0 +1,19 @@
+name: C with autotools
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make distcheck
+      run: make distcheck


### PR DESCRIPTION
This enables a simple GitHub action, which just runs `make` and `make distcheck`. The results will be visible in the pull request view. As an exampe, see [the PR page](https://github.com/jluebbe/can-utils/pull/1) and [the checks page](https://github.com/jluebbe/can-utils/pull/1/checks) in my fork.