### PR TITLE
candump: splitting log files by size

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -114,6 +114,9 @@ extern int optind, opterr, optopt;
 
 static volatile int running = 1;
 
+static int part = 0;
+static unsigned long logmax = 0;
+
 void print_usage(char *prg)
 {
 	fprintf(stderr, "\nUsage: %s [options] <CAN interface>+\n", prg);
@@ -226,8 +229,14 @@ int openlogfile(FILE **logfile) {
 
 	localtime_r(&currtime, &now);
 
-	sprintf(fname, "candump-%04d-%02d-%02d_%02d%02d%02d.log", now.tm_year + 1900,
+	if (!logmax) {
+		sprintf(fname, "candump-%04d-%02d-%02d_%02d%02d%02d.log", now.tm_year + 1900,
 			now.tm_mon + 1, now.tm_mday, now.tm_hour, now.tm_min, now.tm_sec);
+	} else {
+		sprintf(fname, "candump-%04d-%02d-%02d_%02d%02d%02d.pt%d.log", now.tm_year + 1900,
+			now.tm_mon + 1, now.tm_mday, now.tm_hour, now.tm_min, now.tm_sec, part);
+		part++;
+	}
 
 	fprintf(stderr, "Enabling Logfile '%s'\n", fname);
 
@@ -279,7 +288,6 @@ int main(int argc, char **argv)
 	unsigned char color = 0;
 	unsigned char view = 0;
 	unsigned char log = 0;
-	unsigned long logmax = 0;
 	unsigned char logfrmt = 0;
 	int count = 0;
 	int rcvbuf_size = 0;

--- a/candump.c
+++ b/candump.c
@@ -241,6 +241,28 @@ int openlogfile(FILE **logfile) {
 	return 0;
 }
 
+unsigned long convertsize(const char *str) {
+	char *tmp;
+	unsigned long ret = strtoul(str, &tmp, 10);
+
+	if (strlen(tmp) == 0)
+		return ret;
+
+	if (strlen(tmp) == 1)
+	{
+		if (tmp[0] == 'k')
+			return ret * 1024;
+
+		if (tmp[0] == 'm')
+			return ret * 1024 * 1024;
+
+		if (tmp[0] == 'g')
+			return ret * 1024 * 1024 * 1024;
+	}
+	
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	fd_set rdfs;
@@ -381,7 +403,7 @@ int main(int argc, char **argv)
 			break;
 
 		case 'm':
-			logmax = strtoul(optarg, (char **)NULL, 10);  // TODO: Parse strings with sizes: 10mb, 1gb etc
+			logmax = convertsize(optarg);
 			break;
 
 		case 'D':

--- a/candump.c
+++ b/candump.c
@@ -129,6 +129,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -B <can>    (bridge mode - like '-b' with disabled loopback)\n");
 	fprintf(stderr, "         -u <usecs>  (delay bridge forwarding by <usecs> microseconds)\n");
 	fprintf(stderr, "         -l          (log CAN-frames into file. Sets '-s %d' by default)\n", SILENT_ON);
+	fprintf(stderr, "         -m <size>   (log file max size)\n");
 	fprintf(stderr, "         -L          (use log file format on stdout)\n");
 	fprintf(stderr, "         -n <count>  (terminate after reception of <count> CAN frames)\n");
 	fprintf(stderr, "         -r <size>   (set socket receive buffer to <size>)\n");
@@ -256,6 +257,7 @@ int main(int argc, char **argv)
 	unsigned char color = 0;
 	unsigned char view = 0;
 	unsigned char log = 0;
+	unsigned long logmax = 0;
 	unsigned char logfrmt = 0;
 	int count = 0;
 	int rcvbuf_size = 0;
@@ -284,7 +286,7 @@ int main(int argc, char **argv)
 	last_tv.tv_sec  = 0;
 	last_tv.tv_usec = 0;
 
-	while ((opt = getopt(argc, argv, "t:HciaSs:b:B:u:lDdxLn:r:heT:?")) != -1) {
+	while ((opt = getopt(argc, argv, "t:HciaSs:b:B:u:lm:DdxLn:r:heT:?")) != -1) {
 		switch (opt) {
 		case 't':
 			timestamp = optarg[0];
@@ -376,6 +378,10 @@ int main(int argc, char **argv)
 
 		case 'l':
 			log = 1;
+			break;
+
+		case 'm':
+			logmax = strtoul(optarg, (char **)NULL, 10);  // TODO: Parse strings with sizes: 10mb, 1gb etc
 			break;
 
 		case 'D':
@@ -775,7 +781,7 @@ int main(int argc, char **argv)
 					int n = sprintf(line, "(%010ld.%06ld) %*s %s\n",
 						tv.tv_sec, tv.tv_usec,
 						max_devname_len, devname[idx], buf);
-					if (ftell(logfile) + n > 1024) {
+					if (logmax && ftell(logfile) + n > logmax) {
 						fclose(logfile);
 						if (openlogfile(&logfile) != 0)
 							return 1;


### PR DESCRIPTION
We are using candump to log CAN traffic on standalone devices. The log file grows fast. We suggest log file splitting. It could be helpful in some cases like in our one.