### PR TITLE
canfdtest: can_echo_gen(): initialize tx_frames with zero

### DIFF
--- a/canfdtest.c
+++ b/canfdtest.c
@@ -236,7 +236,7 @@ static int can_echo_dut(void)
 
 static int can_echo_gen(void)
 {
-	struct can_frame tx_frames[CAN_MSG_COUNT];
+	struct can_frame tx_frames[CAN_MSG_COUNT] = { };
 	int recv_tx[CAN_MSG_COUNT];
 	struct can_frame rx_frame;
 	unsigned char counter = 0;


### PR DESCRIPTION
This avoids having the padding in the struct can_fame contain bogus
values, which are interpreted by "candump -x" as CAN-FD BRS and ESI
values.

Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>