### PR TITLE
Fix compiler warnings in cangen

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -53,6 +53,7 @@
 #include <libgen.h>
 #include <time.h>
 #include <errno.h>
+#include <getopt.h>
 
 #include <sys/time.h>
 #include <sys/types.h>

--- a/cangen.c
+++ b/cangen.c
@@ -128,7 +128,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "(my favourite default :)\n\n");
 }
 
-void sigterm(int signo)
+static void sigterm(int signo)
 {
 	running = 0;
 }


### PR DESCRIPTION
Nothing serious, but I got two warnings when opening the file with my clang (YouCompleteMe) setup.