### PR TITLE
Rename j* to j1939\1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,10 @@ GNUmakefile.in
 /isotpserver
 /isotpsniffer
 /isotptun
-/jacd
-/jcat
-/jspy
-/jsr
+/j1939acd
+/j1939cat
+/j1939spy
+/j1939sr
 /log2asc
 /log2long
 /slcan_attach

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,10 @@ set(PROGRAMS_CANLIB
 )
 
 set(PROGRAMS_J1939
-    jacd
-    jcat
-    jspy
-    jsr
+    j1939acd
+    j1939cat
+    j1939spy
+    j1939sr
     testj1939
 )
 

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -58,10 +58,10 @@ bin_PROGRAMS = \
 	isotpserver \
 	isotpsniffer \
 	isotptun \
-	jacd \
-	jcat \
-	jspy \
-	jsr \
+	j1939acd \
+	j1939cat \
+	j1939spy \
+	j1939sr \
 	log2asc \
 	log2long \
 	slcan_attach \
@@ -69,10 +69,10 @@ bin_PROGRAMS = \
 	slcanpty \
 	testj1939
 
-jacd_LDADD = libj1939.la
-jcat_LDADD = libj1939.la
-jspy_LDADD = libj1939.la
-jsr_LDADD = libj1939.la
+j1939acd_LDADD = libj1939.la
+j1939cat_LDADD = libj1939.la
+j1939spy_LDADD = libj1939.la
+j1939sr_LDADD = libj1939.la
 testj1939_LDADD = libj1939.la
 
 EXTRA_DIST = \

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ PROGRAMS_ISOTP := \
 	isotptun
 
 PROGRAMS_J1939 := \
-	jacd \
-	jcat \
-	jspy \
-	jsr \
+	j1939acd \
+	j1939cat \
+	j1939spy \
+	j1939sr \
 	testj1939
 
 PROGRAMS_SLCAN := \
@@ -118,10 +118,10 @@ canplayer.o:	lib.h
 cansend.o:	lib.h
 log2asc.o:	lib.h
 log2long.o:	lib.h
-jacd.o:		libj1939.h
-jcat.o:		libj1939.h
-jspy.o:		libj1939.h
-jsr.o:		libj1939.h
+j1939acd.o:		libj1939.h
+j1939cat.o:		libj1939.h
+j1939spy.o:		libj1939.h
+j1939sr.o:		libj1939.h
 testj1939.o:	libj1939.h
 canframelen.o:  canframelen.h
 
@@ -133,9 +133,9 @@ canplayer:	canplayer.o	lib.o
 cansend:	cansend.o	lib.o
 log2asc:	log2asc.o	lib.o
 log2long:	log2long.o	lib.o
-jacd:		jacd.o		libj1939.o
-jcat:		jcat.o		libj1939.o
-jspy:		jspy.o		libj1939.o
-jsr:		jsr.o		libj1939.o
+j1939acd:		j1939acd.o		libj1939.o
+j1939cat:		j1939cat.o		libj1939.o
+j1939spy:		j1939spy.o		libj1939.o
+j1939sr:		j1939sr.o		libj1939.o
 testj1939:	testj1939.o	libj1939.o
 canbusload:	canbusload.o	canframelen.o

--- a/j1939acd.c
+++ b/j1939acd.c
@@ -30,8 +30,8 @@
 #include "libj1939.h"
 
 static const char help_msg[] =
-	"jacd: An SAE J1939 address claiming daemon" "\n"
-	"Usage: jacd [options] NAME [INTF]" "\n"
+	"j1939acd: An SAE J1939 address claiming daemon" "\n"
+	"Usage: j1939acd [options] NAME [INTF]" "\n"
 	"\n"
 	"  -v, --verbose		Increase verbosity" "\n"
 	"  -r, --range=RANGE	Ranges of source addresses" "\n"
@@ -43,7 +43,7 @@ static const char help_msg[] =
 	"NAME is the 64bit nodename" "\n"
 	"\n"
 	"Example:" "\n"
-	"jacd -r 100,80-120 -c /tmp/1122334455667788.jacd 1122334455667788" "\n"
+	"j1939acd -r 100,80-120 -c /tmp/1122334455667788.jacd 1122334455667788" "\n"
 	;
 
 #ifdef _GNU_SOURCE

--- a/j1939cat.c
+++ b/j1939cat.c
@@ -36,13 +36,13 @@
 	_min1 < _min2 ? _min1 : _min2; })
 
 
-struct jcat_stats {
+struct j1939cat_stats {
 	int err;
 	uint32_t tskey;
 	uint32_t send;
 };
 
-struct jcat_priv {
+struct j1939cat_priv {
 	int sock;
 	int infile;
 	int outfile;
@@ -63,12 +63,12 @@ struct jcat_priv {
 
 	struct sock_extended_err *serr;
 	struct scm_timestamping *tss;
-	struct jcat_stats stats;
+	struct j1939cat_stats stats;
 };
 
 static const char help_msg[] =
-	"jcat: netcat tool for j1939\n"
-	"Usage: jcat FROM TO\n"
+	"j1939cat: netcat tool for j1939\n"
+	"Usage: j1939cat FROM TO\n"
 	" FROM / TO	- or [IFACE][:[SA][,[PGN][,NAME]]]\n"
 	"Options:\n"
 	" -i <infile>	(default stdin)\n"
@@ -79,15 +79,15 @@ static const char help_msg[] =
 	" -R <count>	Set send repeat count. Default: 1\n"
 	"\n"
 	"Example:\n"
-	"jcat -i some_file_to_send  can0:0x80 :0x90,0x12300\n"
-	"jcat can0:0x90 -r > /tmp/some_file_to_receive\n"
+	"j1939cat -i some_file_to_send  can0:0x80 :0x90,0x12300\n"
+	"j1939cat can0:0x90 -r > /tmp/some_file_to_receive\n"
 	"\n"
 	;
 
 static const char optstring[] = "?i:vs:rp:P:R:";
 
 
-static void jcat_init_sockaddr_can(struct sockaddr_can *sac)
+static void j1939cat_init_sockaddr_can(struct sockaddr_can *sac)
 {
 	sac->can_family = AF_CAN;
 	sac->can_addr.j1939.addr = J1939_NO_ADDR;
@@ -95,7 +95,7 @@ static void jcat_init_sockaddr_can(struct sockaddr_can *sac)
 	sac->can_addr.j1939.pgn = J1939_NO_PGN;
 }
 
-static ssize_t jcat_send_one(struct jcat_priv *priv, int out_fd,
+static ssize_t j1939cat_send_one(struct j1939cat_priv *priv, int out_fd,
 			     const void *buf, size_t buf_size)
 {
 	ssize_t num_sent;
@@ -129,10 +129,10 @@ static ssize_t jcat_send_one(struct jcat_priv *priv, int out_fd,
 	return num_sent;
 }
 
-static void jcat_print_timestamp(struct jcat_priv *priv, const char *name,
+static void j1939cat_print_timestamp(struct j1939cat_priv *priv, const char *name,
 			      struct timespec *cur)
 {
-	struct jcat_stats *stats = &priv->stats;
+	struct j1939cat_stats *stats = &priv->stats;
 
 	if (!(cur->tv_sec | cur->tv_nsec))
 		return;
@@ -144,7 +144,7 @@ static void jcat_print_timestamp(struct jcat_priv *priv, const char *name,
 	fprintf(stderr, "\n");
 }
 
-static const char *jcat_tstype_to_str(int tstype)
+static const char *j1939cat_tstype_to_str(int tstype)
 {
 	switch (tstype) {
 	case SCM_TSTAMP_SCHED:
@@ -159,9 +159,9 @@ static const char *jcat_tstype_to_str(int tstype)
 }
 
 /* Check the stats of SCM_TIMESTAMPING_OPT_STATS */
-static void jcat_scm_opt_stats(struct jcat_priv *priv, void *buf, int len)
+static void j1939cat_scm_opt_stats(struct j1939cat_priv *priv, void *buf, int len)
 {
-	struct jcat_stats *stats = &priv->stats;
+	struct j1939cat_stats *stats = &priv->stats;
 	int offset = 0;
 
 	while (offset < len) {
@@ -179,9 +179,9 @@ static void jcat_scm_opt_stats(struct jcat_priv *priv, void *buf, int len)
 	}
 }
 
-static int jcat_extract_serr(struct jcat_priv *priv)
+static int j1939cat_extract_serr(struct j1939cat_priv *priv)
 {
-	struct jcat_stats *stats = &priv->stats;
+	struct j1939cat_stats *stats = &priv->stats;
 	struct sock_extended_err *serr = priv->serr;
 	struct scm_timestamping *tss = priv->tss;
 
@@ -205,7 +205,7 @@ static int jcat_extract_serr(struct jcat_priv *priv)
 			      serr->ee_errno);
 		stats->tskey = serr->ee_data;
 
-		jcat_print_timestamp(priv, jcat_tstype_to_str(serr->ee_info),
+		j1939cat_print_timestamp(priv, j1939cat_tstype_to_str(serr->ee_info),
 				     &tss->ts[0]);
 
 		if (serr->ee_info == SCM_TSTAMP_SCHED)
@@ -232,7 +232,7 @@ static int jcat_extract_serr(struct jcat_priv *priv)
 			warnx("serr: unknown ee_info: %i",
 			      serr->ee_info);
 
-		jcat_print_timestamp(priv, "  ABT", &tss->ts[0]);
+		j1939cat_print_timestamp(priv, "  ABT", &tss->ts[0]);
 		warnx("serr: tx error: %i, %s", serr->ee_errno, strerror(serr->ee_errno));
 
 		return serr->ee_errno;
@@ -243,7 +243,7 @@ static int jcat_extract_serr(struct jcat_priv *priv)
 	return 0;
 }
 
-static int jcat_parse_cm(struct jcat_priv *priv, struct cmsghdr *cm)
+static int j1939cat_parse_cm(struct j1939cat_priv *priv, struct cmsghdr *cm)
 {
 	const size_t hdr_len = CMSG_ALIGN(sizeof(struct cmsghdr));
 
@@ -253,7 +253,7 @@ static int jcat_parse_cm(struct jcat_priv *priv, struct cmsghdr *cm)
 		void *jstats = (void *)CMSG_DATA(cm);
 
 		/* Activated with SOF_TIMESTAMPING_OPT_STATS */
-		jcat_scm_opt_stats(priv, jstats, cm->cmsg_len - hdr_len);
+		j1939cat_scm_opt_stats(priv, jstats, cm->cmsg_len - hdr_len);
 	} else if (cm->cmsg_level == SOL_CAN_J1939 &&
 		   cm->cmsg_type == SCM_J1939_ERRQUEUE) {
 		priv->serr = (void *)CMSG_DATA(cm);
@@ -264,7 +264,7 @@ static int jcat_parse_cm(struct jcat_priv *priv, struct cmsghdr *cm)
 	return 0;
 }
 
-static int jcat_recv_err(struct jcat_priv *priv)
+static int j1939cat_recv_err(struct j1939cat_priv *priv)
 {
 	char control[100];
 	struct cmsghdr *cm;
@@ -285,18 +285,18 @@ static int jcat_recv_err(struct jcat_priv *priv)
 
 	for (cm = CMSG_FIRSTHDR(&msg); cm && cm->cmsg_len;
 	     cm = CMSG_NXTHDR(&msg, cm)) {
-		jcat_parse_cm(priv, cm);
+		j1939cat_parse_cm(priv, cm);
 		if (priv->serr && priv->tss)
-			return jcat_extract_serr(priv);
+			return j1939cat_extract_serr(priv);
 	}
 
 	return 0;
 }
 
-static int jcat_send_loop(struct jcat_priv *priv, int out_fd, char *buf,
+static int j1939cat_send_loop(struct j1939cat_priv *priv, int out_fd, char *buf,
 			  size_t buf_size)
 {
-	struct jcat_stats *stats = &priv->stats;
+	struct j1939cat_stats *stats = &priv->stats;
 	ssize_t count;
 	char *tmp_buf = buf;
 	unsigned int events = POLLOUT | POLLERR;
@@ -328,7 +328,7 @@ static int jcat_send_loop(struct jcat_priv *priv, int out_fd, char *buf,
 			}
 
 			if (fds.revents & POLLERR) {
-				ret = jcat_recv_err(priv);
+				ret = j1939cat_recv_err(priv);
 				if (ret == -EINTR)
 					continue;
 				else if (ret)
@@ -339,12 +339,12 @@ static int jcat_send_loop(struct jcat_priv *priv, int out_fd, char *buf,
 			}
 
 			if (fds.revents & POLLOUT) {
-				num_sent = jcat_send_one(priv, out_fd, tmp_buf, count);
+				num_sent = j1939cat_send_one(priv, out_fd, tmp_buf, count);
 				if (num_sent < 0)
 					return num_sent;
 			}
 		} else {
-			num_sent = jcat_send_one(priv, out_fd, tmp_buf, count);
+			num_sent = j1939cat_send_one(priv, out_fd, tmp_buf, count);
 			if (num_sent < 0)
 				return num_sent;
 		}
@@ -366,7 +366,7 @@ static int jcat_send_loop(struct jcat_priv *priv, int out_fd, char *buf,
 	return 0;
 }
 
-static int jcat_sendfile(struct jcat_priv *priv, int out_fd, int in_fd,
+static int j1939cat_sendfile(struct j1939cat_priv *priv, int out_fd, int in_fd,
 			 off_t *offset, size_t count)
 {
 	int ret = EXIT_SUCCESS;
@@ -408,7 +408,7 @@ static int jcat_sendfile(struct jcat_priv *priv, int out_fd, int in_fd,
 		if (num_read == 0)
 			break; /* EOF */
 
-		ret = jcat_send_loop(priv, out_fd, buf, num_read);
+		ret = j1939cat_send_loop(priv, out_fd, buf, num_read);
 		if (ret)
 			goto do_free;
 
@@ -437,7 +437,7 @@ do_nofree:
 	return ret;
 }
 
-static size_t jcat_get_file_size(int fd)
+static size_t j1939cat_get_file_size(int fd)
 {
 	off_t offset;
 
@@ -451,20 +451,20 @@ static size_t jcat_get_file_size(int fd)
 	return offset;
 }
 
-static int jcat_send(struct jcat_priv *priv)
+static int j1939cat_send(struct j1939cat_priv *priv)
 {
 	unsigned int size = 0;
 	int ret, i;
 
 	if (priv->todo_filesize)
-		size = jcat_get_file_size(priv->infile);
+		size = j1939cat_get_file_size(priv->infile);
 
 	if (!size)
 		return EXIT_FAILURE;
 
 	for (i = 0; i < priv->repeat; i++) {
 		priv->round++;
-		ret = jcat_sendfile(priv, priv->sock, priv->infile, NULL, size);
+		ret = j1939cat_sendfile(priv, priv->sock, priv->infile, NULL, size);
 		if (ret)
 			break;
 
@@ -475,7 +475,7 @@ static int jcat_send(struct jcat_priv *priv)
 	return ret;
 }
 
-static int jcat_recv_one(struct jcat_priv *priv, uint8_t *buf, size_t buf_size)
+static int j1939cat_recv_one(struct j1939cat_priv *priv, uint8_t *buf, size_t buf_size)
 {
 	int ret;
 
@@ -494,7 +494,7 @@ static int jcat_recv_one(struct jcat_priv *priv, uint8_t *buf, size_t buf_size)
 	return EXIT_SUCCESS;
 }
 
-static int jcat_recv(struct jcat_priv *priv)
+static int j1939cat_recv(struct j1939cat_priv *priv)
 {
 	int ret = EXIT_SUCCESS;
 	size_t buf_size;
@@ -508,7 +508,7 @@ static int jcat_recv(struct jcat_priv *priv)
 	}
 
 	while (priv->todo_recv) {
-		ret = jcat_recv_one(priv, buf, buf_size);
+		ret = j1939cat_recv_one(priv, buf, buf_size);
 		if (ret)
 			break;
 	}
@@ -517,7 +517,7 @@ static int jcat_recv(struct jcat_priv *priv)
 	return ret;
 }
 
-static int jcat_sock_prepare(struct jcat_priv *priv)
+static int j1939cat_sock_prepare(struct j1939cat_priv *priv)
 {
 	unsigned int sock_opt;
 	int value;
@@ -581,7 +581,7 @@ static int jcat_sock_prepare(struct jcat_priv *priv)
 	return EXIT_SUCCESS;
 }
 
-static int jcat_parse_args(struct jcat_priv *priv, int argc, char *argv[])
+static int j1939cat_parse_args(struct j1939cat_priv *priv, int argc, char *argv[])
 {
 	int opt;
 
@@ -641,7 +641,7 @@ static int jcat_parse_args(struct jcat_priv *priv, int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-	struct jcat_priv *priv;
+	struct j1939cat_priv *priv;
 	int ret;
 
 	priv = malloc(sizeof(*priv));
@@ -657,21 +657,21 @@ int main(int argc, char *argv[])
 	priv->polltimeout = 100000;
 	priv->repeat = 1;
 
-	jcat_init_sockaddr_can(&priv->sockname);
-	jcat_init_sockaddr_can(&priv->peername);
+	j1939cat_init_sockaddr_can(&priv->sockname);
+	j1939cat_init_sockaddr_can(&priv->peername);
 
-	ret = jcat_parse_args(priv, argc, argv);
+	ret = j1939cat_parse_args(priv, argc, argv);
 	if (ret)
 		return ret;
 
-	ret = jcat_sock_prepare(priv);
+	ret = j1939cat_sock_prepare(priv);
 	if (ret)
 		return ret;
 
 	if (priv->todo_recv)
-		ret = jcat_recv(priv);
+		ret = j1939cat_recv(priv);
 	else
-		ret = jcat_send(priv);
+		ret = j1939cat_send(priv);
 
 	close(priv->infile);
 	close(priv->outfile);

--- a/j1939spy.c
+++ b/j1939spy.c
@@ -30,8 +30,8 @@
  * getopt
  */
 static const char help_msg[] =
-	"jspy: An SAE J1939 spy utility" "\n"
-	"Usage: jspy [OPTION...] [[IFACE:][NAME|SA][,PGN]]" "\n"
+	"j1939spy: An SAE J1939 spy utility" "\n"
+	"Usage: j1939spy [OPTION...] [[IFACE:][NAME|SA][,PGN]]" "\n"
 	"\n"
 	"  -v, --verbose		Increase verbosity" "\n"
 	"  -P, --promisc		Run in promiscuous mode" "\n"

--- a/j1939sr.c
+++ b/j1939sr.c
@@ -31,8 +31,8 @@
  * getopt
  */
 static const char help_msg[] =
-	"jsr: An SAE J1939 send/recv utility" "\n"
-	"Usage: jsr [OPTION...] SOURCE [DEST]" "\n"
+	"j1939sr: An SAE J1939 send/recv utility" "\n"
+	"Usage: j1939sr [OPTION...] SOURCE [DEST]" "\n"
 	"\n"
 	"  -v, --verbose		Increase verbosity" "\n"
 	"  -p, --priority=VAL	J1939 priority (0..7, default 6)" "\n"


### PR DESCRIPTION
Using j*smthng* for j1939-related tools is not very good for 2 reasons:
1. j prefix is not very informative;
2. jcat name is used by journal cat tool from popular sleuthkit toolkit;
2`. jacd sounds very similar to jackd.
2``. Possible future name conflicts for new tools.

Thus I renamed j* to j1939\1 to deal with this issue.

Signed-off-by: Alexander GQ Gerasiov <gq@cs.msu.su>