### PR TITLE
cangen.c: added -c option for bursty output.

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -441,6 +441,7 @@ int main(int argc, char **argv)
 			else
 				fprint_canframe(stdout, &frame, "\n", 1, maxdlen);
 		}
+
 resend:
 		nbytes = write(s, &frame, mtu);
 		if (nbytes < 0) {
@@ -466,11 +467,14 @@ resend:
 			fprintf(stderr, "write: incomplete CAN frame\n");
 			return 1;
 		}
+
 		burst_sent_count++;
 		if (gap && burst_sent_count >= burst_count) /* gap == 0 => performance test :-] */
-			if (nanosleep(&ts, NULL)) return 1;
+			if (nanosleep(&ts, NULL))
+				return 1;
 
-		if(burst_sent_count >= burst_count) burst_sent_count = 0;
+		if (burst_sent_count >= burst_count)
+			burst_sent_count = 0;
 
 		if (id_mode == MODE_INCREMENT)
 			frame.can_id++;


### PR DESCRIPTION
I had an idea to try and reproduce a problem I have with some bursty traffic and RX overrun erors. The bursty traffic is trying to mimic bursts of messages that might happen on CANOpen when multiple nodes sends their PDO messages as a reponse to a SYNC message.

Does this make sense to include in the cangen tool? If so here is a pull request.

Specify -c 100 to have 100 packets sent in a burst before gap.

To have a burst of 100 message with a gap of 200 milliseconds between each burst specify: -g 200 -c 100.