### PR TITLE
Android.mk: fix Android 10 build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,6 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 
 PRIVATE_LOCAL_CFLAGS := -O2 -g -W -Wall		\
+			-Wno-error=unused-parameter	\
 			-DSO_RXQ_OVFL=40	\
 			-DPF_CAN=29		\
 			-DAF_CAN=PF_CAN


### PR DESCRIPTION
Android now uses clang with Werror by default which prevents from
building.
Removing Werror for the current warnings.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>