### PR TITLE
Added CAN message direction (Tx or Rx) for logging in candump and log…

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -706,9 +706,9 @@ int main(int argc, char **argv)
 
 					/* log CAN frame with absolute timestamp & device */
 					sprint_canframe(buf, &frame, 0, maxdlen);
-					fprintf(logfile, "(%010ld.%06ld) %*s %s\n",
+					fprintf(logfile, "(%010ld.%06ld) %*s %s %s\n",
 						tv.tv_sec, tv.tv_usec,
-						max_devname_len, devname[idx], buf);
+						max_devname_len, devname[idx], (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx", buf);
 				}
 
 				if ((logfrmt) && (silent == SILENT_OFF)){

--- a/log2asc.c
+++ b/log2asc.c
@@ -71,7 +71,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -r  (supress dlc for RTR frames - pre v8.5 tools)\n");
 }
 
-void can_asc(struct canfd_frame *cf, int devno, int nortrdlc, FILE *outfile)
+void can_asc(struct canfd_frame *cf, int devno, int nortrdlc, FILE *outfile, char *msgdir)
 {
 	int i;
 	char id[10];
@@ -83,7 +83,9 @@ void can_asc(struct canfd_frame *cf, int devno, int nortrdlc, FILE *outfile)
 	else {
 		sprintf(id, "%X%c", cf->can_id & CAN_EFF_MASK,
 			(cf->can_id & CAN_EFF_FLAG)?'x':' ');
-		fprintf(outfile, "%-15s Rx   ", id);
+
+		fprintf(outfile, "%-15s ", id);
+		fprintf(outfile, "%s   ", msgdir); /* message direction (Tx or Rx) */
 
 		if (cf->can_id & CAN_RTR_FLAG) {
 			if (nortrdlc)
@@ -100,7 +102,7 @@ void can_asc(struct canfd_frame *cf, int devno, int nortrdlc, FILE *outfile)
 	}
 }
 
-void canfd_asc(struct canfd_frame *cf, int devno, int mtu, FILE *outfile)
+void canfd_asc(struct canfd_frame *cf, int devno, int mtu, FILE *outfile, char *msgdir)
 {
 	int i;
 	char id[10];
@@ -114,6 +116,7 @@ void canfd_asc(struct canfd_frame *cf, int devno, int mtu, FILE *outfile)
 #define ASC_F_ESI 0x00004000
 
 	fprintf(outfile, "CANFD %3d Rx ", devno); /* 3 column channel number right aligned */
+	fprintf(outfile, "%s ", msgdir); /* message direction (Tx or Rx) */
 
 	sprintf(id, "%X%c", cf->can_id & CAN_EFF_MASK,
 		(cf->can_id & CAN_EFF_FLAG)?'x':' ');
@@ -148,6 +151,7 @@ void canfd_asc(struct canfd_frame *cf, int devno, int mtu, FILE *outfile)
 int main(int argc, char **argv)
 {
 	static char buf[BUFSZ], device[BUFSZ], ascframe[BUFSZ];
+	static char msgdir[2];
 
 	struct canfd_frame cf;
 	static struct timeval tv, start_tv;
@@ -223,8 +227,8 @@ int main(int argc, char **argv)
 		if (buf[0] != '(')
 			continue;
 
-		if (sscanf(buf, "(%ld.%ld) %s %s", &tv.tv_sec, &tv.tv_usec,
-			   device, ascframe) != 4) {
+		if (sscanf(buf, "(%ld.%ld) %s %s %s", &tv.tv_sec, &tv.tv_usec,
+			   device, msgdir, ascframe) != 5) {
 			fprintf(stderr, "incorrect line format in logfile\n");
 			return 1;
 		}
@@ -267,9 +271,9 @@ int main(int argc, char **argv)
 				fprintf(outfile, "%4ld.%06ld ", tv.tv_sec, tv.tv_usec);
 
 			if ((mtu == CAN_MTU) && (fdfmt == 0))
-				can_asc(&cf, devno, nortrdlc, outfile);
+				can_asc(&cf, devno, nortrdlc, outfile, msgdir);
 			else
-				canfd_asc(&cf, devno, mtu, outfile);
+				canfd_asc(&cf, devno, mtu, outfile, msgdir);
 
 			if (crlf)
 				fprintf(outfile, "\r");


### PR DESCRIPTION
Added Tx and Rx for can messages for candump log recording. Log2asc was appending Rx for all the recorded can messages and now it is updated to parse and append correct message direction. With this the can trace will be more useful for analysis.