### PR TITLE
Added CAN message direction (Tx or Rx) for log recording

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -72,6 +72,8 @@ void print_usage(char *prg)
 
 void prframe(FILE *file, struct timeval *tv, int dev, struct canfd_frame *cf, unsigned int max_dlen, char *msgdir) {
 
+	char buf[CL_CFSZ]; /* max length */
+
 	fprintf(file, "(%ld.%06ld) ", tv->tv_sec, tv->tv_usec);
 
 	if (dev > 0)
@@ -79,9 +81,11 @@ void prframe(FILE *file, struct timeval *tv, int dev, struct canfd_frame *cf, un
 	else
 		fprintf(file, "canX ");
 
-	fprintf(file, "%s ", msgdir);
+	sprint_canframe(buf, cf, 0, max_dlen);
+	fprintf(file, "%-25s ", buf);
 
-	fprint_canframe(file, cf, "\n", 0, max_dlen);
+	fprintf(file, "%s \n", msgdir);
+
 }
 
 void get_can_id(struct canfd_frame *cf, char *idstring, int base) {

--- a/asc2log.c
+++ b/asc2log.c
@@ -82,7 +82,7 @@ void prframe(FILE *file, struct timeval *tv, int dev, struct canfd_frame *cf, un
 		fprintf(file, "canX ");
 
 	sprint_canframe(buf, cf, 0, max_dlen);
-	fprintf(file, "%-25s ", buf);
+	fprintf(file, "%s ", buf);
 
 	fprintf(file, "%s \n", msgdir);
 

--- a/candump.c
+++ b/candump.c
@@ -706,9 +706,9 @@ int main(int argc, char **argv)
 
 					/* log CAN frame with absolute timestamp & device */
 					sprint_canframe(buf, &frame, 0, maxdlen);
-					fprintf(logfile, "(%010ld.%06ld) %*s %s\n",
+					fprintf(logfile, "(%010ld.%06ld) %*s %s %s\n",
 						tv.tv_sec, tv.tv_usec,
-						max_devname_len, devname[idx], buf);
+						max_devname_len, devname[idx], (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx", buf);
 				}
 
 				if ((logfrmt) && (silent == SILENT_OFF)){

--- a/candump.c
+++ b/candump.c
@@ -706,7 +706,7 @@ int main(int argc, char **argv)
 
 					/* log CAN frame with absolute timestamp & device */
 					sprint_canframe(buf, &frame, 0, maxdlen);
-					fprintf(logfile, "(%010ld.%06ld) %*s %-25s %s\n",
+					fprintf(logfile, "(%010ld.%06ld) %*s %s %s\n",
 						tv.tv_sec, tv.tv_usec,
 						max_devname_len, devname[idx], buf, (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx");
 				}
@@ -716,9 +716,9 @@ int main(int argc, char **argv)
 
 					/* print CAN frame in log file style to stdout */
 					sprint_canframe(buf, &frame, 0, maxdlen);
-					printf("(%010ld.%06ld) %*s %s\n",
+					printf("(%010ld.%06ld) %*s %s %s\n",
 					       tv.tv_sec, tv.tv_usec,
-					       max_devname_len, devname[idx], buf);
+					       max_devname_len, devname[idx], buf, (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx");
 					goto out_fflush; /* no other output to stdout */
 				}
 

--- a/candump.c
+++ b/candump.c
@@ -706,9 +706,9 @@ int main(int argc, char **argv)
 
 					/* log CAN frame with absolute timestamp & device */
 					sprint_canframe(buf, &frame, 0, maxdlen);
-					fprintf(logfile, "(%010ld.%06ld) %*s %s %s\n",
+					fprintf(logfile, "(%010ld.%06ld) %*s %-25s %s\n",
 						tv.tv_sec, tv.tv_usec,
-						max_devname_len, devname[idx], (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx", buf);
+						max_devname_len, devname[idx], buf, (msg.msg_flags & MSG_DONTROUTE)?"Tx":"Rx");
 				}
 
 				if ((logfrmt) && (silent == SILENT_OFF)){

--- a/log2asc.c
+++ b/log2asc.c
@@ -227,9 +227,13 @@ int main(int argc, char **argv)
 			continue;
 
 		if (sscanf(buf, "(%ld.%ld) %s %s %s", &tv.tv_sec, &tv.tv_usec,
-			   device, msgdir, ascframe) != 5) {
+			   device, ascframe,msgdir) != 5) {
+			sscanf("Rx", "%s", msgdir); /* To support candump log file without Rx/Tx info */
+			if (sscanf(buf, "(%ld.%ld) %s %s", &tv.tv_sec, &tv.tv_usec,
+				   device, ascframe) != 4) {
 			fprintf(stderr, "incorrect line format in logfile\n");
 			return 1;
+		}
 		}
 
 		if (!start_tv.tv_sec) { /* print banner */


### PR DESCRIPTION
Log file recording updated with CAN Message direction.
Changes Made:
    1.Added CAN message direction (Tx or Rx) for log file recording in candump.
    2.Log file converters log2asc and asc2log are updated to parse the message direction.

NOTE:
Log2asc was appending "Rx" for all the recorded can messages for conversion. With this the trace was not much helpful for analysis. So they are updated to reflect correct correct message direction.