### PR TITLE
J1939 clang fixes

### DIFF
--- a/j1939acd.c
+++ b/j1939acd.c
@@ -200,7 +200,7 @@ static int open_socket(const char *device, uint64_t name)
 			.addr = J1939_IDLE_ADDR,
 			.pgn = J1939_NO_PGN,
 		},
-		.can_ifindex = if_nametoindex(s.intf),
+		.can_ifindex = if_nametoindex(device),
 	};
 
 	if (s.verbose)

--- a/j1939cat.c
+++ b/j1939cat.c
@@ -165,11 +165,11 @@ static void j1939cat_scm_opt_stats(struct j1939cat_priv *priv, void *buf, int le
 	int offset = 0;
 
 	while (offset < len) {
-		struct nlattr *nla = (struct nlattr *) (buf + offset);
+		struct nlattr *nla = (struct nlattr *) ((char *)buf + offset);
 
 		switch (nla->nla_type) {
 		case J1939_NLA_BYTES_ACKED:
-			stats->send = *(uint32_t *)((void *)nla + NLA_HDRLEN);
+			stats->send = *(uint32_t *)((char *)nla + NLA_HDRLEN);
 			break;
 		default:
 			warnx("not supported J1939_NLA field\n");

--- a/j1939cat.c
+++ b/j1939cat.c
@@ -121,7 +121,7 @@ static ssize_t j1939cat_send_one(struct j1939cat_priv *priv, int out_fd,
 		return -EINVAL;
 	}
 
-	if (num_sent > buf_size) /* Should never happen */ {
+	if (num_sent > (ssize_t)buf_size) /* Should never happen */ {
 		warn("%s: send more then read", __func__);
 		return -EINVAL;
 	}
@@ -372,7 +372,8 @@ static int j1939cat_sendfile(struct j1939cat_priv *priv, int out_fd, int in_fd,
 	int ret = EXIT_SUCCESS;
 	off_t orig = 0;
 	char *buf;
-	size_t to_read, num_read, buf_size;
+	ssize_t num_read;
+	size_t to_read, buf_size;
 
 	buf_size = min(priv->max_transfer, count);
 	buf = malloc(buf_size);
@@ -454,7 +455,8 @@ static size_t j1939cat_get_file_size(int fd)
 static int j1939cat_send(struct j1939cat_priv *priv)
 {
 	unsigned int size = 0;
-	int ret, i;
+	unsigned int i;
+	int ret;
 
 	if (priv->todo_filesize)
 		size = j1939cat_get_file_size(priv->infile);

--- a/j1939spy.c
+++ b/j1939spy.c
@@ -95,8 +95,8 @@ static uint8_t *buf;
  */
 int main(int argc, char **argv)
 {
-	int ret, sock, j, opt;
-	unsigned int len;
+	int ret, sock, opt;
+	unsigned int j, len;
 	struct timeval tref, tdut, ttmp;
 	struct sockaddr_can src;
 	struct j1939_filter filt;
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
 
 		printf("[%i%s]", len, (msg.msg_flags & MSG_TRUNC) ? "..." : "");
 		for (j = 0; j < len; ) {
-			int end = j + 4;
+			unsigned int end = j + 4;
 			if (end > len)
 				end = len;
 			printf(" ");

--- a/libj1939.c
+++ b/libj1939.c
@@ -53,7 +53,7 @@ static const char *libj1939_ifnam(int ifindex)
 	fetch_names();
 
 	for (lp = saved; lp->if_index; ++lp) {
-		if (lp->if_index == ifindex)
+		if (lp->if_index == (unsigned int)ifindex)
 			return lp->if_name;
 	}
 	if (cached) {

--- a/testj1939.c
+++ b/testj1939.c
@@ -72,7 +72,8 @@ static void schedule_oneshot_itimer(double delay)
 /* main */
 int main(int argc, char *argv[])
 {
-	int ret, sock, opt, j;
+	int ret, sock, opt;
+	unsigned int j;
 	int verbose = 0;
 	socklen_t peernamelen;
 	struct sockaddr_can sockname = {
@@ -92,7 +93,8 @@ int main(int argc, char *argv[])
 	};
 	uint8_t dat[128];
 	int valid_peername = 0;
-	int todo_send = 0, todo_recv = 0, todo_echo = 0, todo_prio = -1;
+	unsigned int todo_send = 0;
+	int todo_recv = 0, todo_echo = 0, todo_prio = -1;
 	int todo_connect = 0, todo_names = 0, todo_wait = 0, todo_rebind = 0;
 	int todo_broadcast = 0, todo_promisc = 0;
 	int no_bind = 0;
@@ -289,16 +291,16 @@ int main(int argc, char *argv[])
 				err(1, "sendto");
 		}
 		if (todo_recv) {
-			int i = 0;
+			int i;
 
 			if (todo_names && peername.can_addr.j1939.name)
 				printf("%016llx ", peername.can_addr.j1939.name);
 			printf("%02x %05x:", peername.can_addr.j1939.addr,
 					peername.can_addr.j1939.pgn);
-			for (j = 0; j < ret; ++j, i++) {
-				if (i == 8) {
+			for (i = 0, j = 0; i < ret; ++i, j++) {
+				if (j == 8) {
 					printf("\n%05x    ", j);
-					i = 0;
+					j = 0;
 				}
 				printf(" %02x", dat[j]);
 			}


### PR DESCRIPTION
Fix clang warnings in recently added j1939 files.
See Garys fixes here:
https://github.com/linux-can/can-utils/commit/43610bd6217cd8b38455ea9af6783fc04547929f
and here:
https://github.com/linux-can/can-utils/commit/46895a41c5241971f48bf936056de597d8190e29