### PR TITLE
can-j1939-kickstart.md: fix example in documentation

### DIFF
--- a/can-j1939-kickstart.md
+++ b/can-j1939-kickstart.md
@@ -44,7 +44,7 @@ You should have this output in terminal 1
 	40 02300: 01 23
 
 This means, from NAME 0, SA 40, PGN 02300 was received,
-with 2 databytes, *01* & *02*.
+with 2 databytes, *01* & *23*.
 
 now emit this CAN message:
 


### PR DESCRIPTION
Incorrect value of the second databyte '23'