### PR TITLE
Changed hardcoded hex number 0x0fed8 to j1939.h constant "J1939_PGN_ADDRESS_COMMANDED"

### DIFF
--- a/j1939acd.c
+++ b/j1939acd.c
@@ -184,7 +184,7 @@ static const struct j1939_filter filt[] = {
 		.pgn = J1939_PGN_REQUEST,
 		.pgn_mask = J1939_PGN_PDU1_MAX,
 	}, {
-		.pgn = 0x0fed8,
+		.pgn = J1939_PGN_ADDRESS_COMMANDED,
 		.pgn_mask = J1939_PGN_MAX,
 	},
 };


### PR DESCRIPTION
Use include constant instead of hardcoded constant