### PR TITLE
testj1939: print proper offset in the data damp

### DIFF
--- a/testj1939.c
+++ b/testj1939.c
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
 					peername.can_addr.j1939.pgn);
 			for (i = 0, j = 0; i < ret; ++i, j++) {
 				if (j == 8) {
-					printf("\n%05x    ", j);
+					printf("\n%05x    ", i);
 					j = 0;
 				}
 				printf(" %02x", dat[i]);


### PR DESCRIPTION
without this patch we will always print "0008" on each line

Signed-off-by: Oleksij Rempel <o.rempel@pengutronix.de>