### PR TITLE
canfdtest: fix frame consistency check

### DIFF
--- a/canfdtest.c
+++ b/canfdtest.c
@@ -215,7 +215,7 @@ static int check_frame(const struct can_frame *frame)
 	}
 	
 	for (i = 1; i < frame->can_dlc; i++) {
-		if (frame->data[i] != frame->data[i-1]) {
+		if (frame->data[i] != (uint8_t)(frame->data[i-1] + 1)) {
 			printf("Frame inconsistent!\n");
 			print_frame(frame, 0);
 			err = -1;


### PR DESCRIPTION
This patch fixes the issue reported in:

https://github.com/linux-can/can-utils/commit/d7f28a0ffe36f73fe08729202f9c49ca5cac1dd4
https://github.com/linux-can/can-utils/issues/236

Reported-by: https://github.com/ronitnvidia
Fixes: d7f28a0ffe36 ("canfdtest: can_echo_dut(): check received frame for consistency")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>