### PR TITLE
convert usleep to nanosleep

### DIFF
--- a/bcmserver.c
+++ b/bcmserver.c
@@ -114,6 +114,7 @@
 #include <string.h>
 #include <signal.h>
 #include <errno.h>
+#include <time.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -180,8 +181,12 @@ int main(void)
 	saddr.sin_port = htons(PORT);
 
 	while(bind(sl,(struct sockaddr*)&saddr, sizeof(saddr)) < 0) {
+		struct timespec f = {
+			.tv_nsec = 100 * 1000 * 1000,
+		};
+
 		printf(".");fflush(NULL);
-		usleep(100000);
+		nanosleep(&f, NULL);
 	}
 
 	if (listen(sl,3) != 0) {

--- a/canlogserver.c
+++ b/canlogserver.c
@@ -281,8 +281,12 @@ int main(int argc, char **argv)
 	inaddr.sin_port = htons(port);
 
 	while(bind(socki, (struct sockaddr*)&inaddr, sizeof(inaddr)) < 0) {
+		struct timespec f = {
+			.tv_nsec = 100 * 1000 * 1000,
+		};
+
 		printf(".");fflush(NULL);
-		usleep(100000);
+		nanosleep(&f, NULL);
 	}
 
 	if (listen(socki, 3) != 0) {

--- a/isotpserver.c
+++ b/isotpserver.c
@@ -64,6 +64,7 @@
 #include <string.h>
 #include <signal.h>
 #include <errno.h>
+#include <time.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -299,9 +300,13 @@ int main(int argc, char **argv)
 	saddr.sin_port = htons(local_port);
 
 	while(bind(sl,(struct sockaddr*)&saddr, sizeof(saddr)) < 0) {
+		struct timespec f = {
+			.tv_nsec = 100 * 1000 * 1000,
+		};
+
 		printf(".");
 		fflush(NULL);
-		usleep(100000);
+		nanosleep(&f, NULL);
 	}
 
 	if (listen(sl, 3) != 0) {


### PR DESCRIPTION
usleep is removed in POSIX 2008.

Signed-off-by: Rosen Penev <rosenp@gmail.com>