### PR TITLE
change {} to {0}

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -224,7 +224,7 @@ void eval_canfd(char* buf, struct timeval *date_tvp, char timestamps, int dplace
 	int interface;
 	static struct timeval tv; /* current frame timestamp */
 	static struct timeval read_tv; /* frame timestamp from ASC file */
-	struct canfd_frame cf = {};
+	struct canfd_frame cf = { 0 };
 	unsigned char brs, esi, ctmp;
 	unsigned int flags;
 	int dlc, dlen = 0;

--- a/cangw.c
+++ b/cangw.c
@@ -706,8 +706,8 @@ int main(int argc, char **argv)
 	struct can_filter filter;
 	struct sockaddr_nl nladdr;
 
-	struct cgw_csum_xor cs_xor = {};
-	struct cgw_csum_crc8 cs_crc8 = {};
+	struct cgw_csum_xor cs_xor = { 0 };
+	struct cgw_csum_crc8 cs_crc8 = { 0 };
 	char crc8tab[513] = {0};
 
 	struct modattr modmsg[CGW_MOD_FUNCS];

--- a/j1939acd.c
+++ b/j1939acd.c
@@ -365,7 +365,7 @@ static void install_signal(int sig)
 static void schedule_itimer(int msec)
 {
 	int ret;
-	struct itimerval val = {};
+	struct itimerval val = { 0 };
 
 	val.it_value.tv_sec = msec / 1000;
 	val.it_value.tv_usec = (msec % 1000) * 1000;

--- a/testj1939.c
+++ b/testj1939.c
@@ -61,7 +61,7 @@ static void onsigalrm(int sig)
 
 static void schedule_oneshot_itimer(double delay)
 {
-	struct itimerval it = {};
+	struct itimerval it = { 0 };
 
 	it.it_value.tv_sec = delay;
 	it.it_value.tv_usec = (long)(delay * 1e6) % 1000000;


### PR DESCRIPTION
The former throws a pedantic warning.

Signed-off-by: Rosen Penev <rosenp@gmail.com>