### PR TITLE
Makefile: fix indention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ canplayer.o:	lib.h
 cansend.o:	lib.h
 log2asc.o:	lib.h
 log2long.o:	lib.h
-j1939acd.o:		libj1939.h
-j1939cat.o:		libj1939.h
-j1939spy.o:		libj1939.h
-j1939sr.o:		libj1939.h
+j1939acd.o:	libj1939.h
+j1939cat.o:	libj1939.h
+j1939spy.o:	libj1939.h
+j1939sr.o:	libj1939.h
 testj1939.o:	libj1939.h
 canframelen.o:  canframelen.h
 
@@ -133,9 +133,9 @@ canplayer:	canplayer.o	lib.o
 cansend:	cansend.o	lib.o
 log2asc:	log2asc.o	lib.o
 log2long:	log2long.o	lib.o
-j1939acd:		j1939acd.o		libj1939.o
-j1939cat:		j1939cat.o		libj1939.o
-j1939spy:		j1939spy.o		libj1939.o
-j1939sr:		j1939sr.o		libj1939.o
+j1939acd:	j1939acd.o	libj1939.o
+j1939cat:	j1939cat.o	libj1939.o
+j1939spy:	j1939spy.o	libj1939.o
+j1939sr:	j1939sr.o	libj1939.o
 testj1939:	testj1939.o	libj1939.o
 canbusload:	canbusload.o	canframelen.o


### PR DESCRIPTION
This patch fixes the indention, which was broken while renaming the j1939
tools.

Fixes: 8106214b5503 ("Rename j* to j1939\1")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>