### PR TITLE
Android.mk: remove duplicated cansequence definition

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -161,21 +161,6 @@ LOCAL_CFLAGS := $(PRIVATE_LOCAL_CFLAGS)
 include $(BUILD_EXECUTABLE)
 
 #
-# cansequence
-#
-
-include $(CLEAR_VARS)
-
-LOCAL_SRC_FILES := cansequence.c
-LOCAL_MODULE := cansequence
-LOCAL_MODULE_TAGS := optional
-LOCAL_STATIC_LIBRARIES := libcan
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include/
-LOCAL_CFLAGS := $(PRIVATE_LOCAL_CFLAGS)
-
-include $(BUILD_EXECUTABLE)
-
-#
 # bcmserver
 #
 


### PR DESCRIPTION
Otherwise throwing the following error:
build/make/core/base_rules.mk:325: error: external/can-utils:
MODULE.TARGET.EXECUTABLES.cansequence already defined by
external/can-utils.

Fixes: a726c2a ("Merge branch 'cansequence' of
github.com:marckleinebudde/can-utils into master")

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>