### PR TITLE
cansequence: do_send(): remove unneeded cast

### DIFF
--- a/cansequence.c
+++ b/cansequence.c
@@ -229,7 +229,7 @@ static void do_send()
 			}
 		}
 
-		(unsigned char)frame.data[0]++;
+		frame.data[0]++;
 		sequence++;
 
 		if (verbose && !sequence)


### PR DESCRIPTION
This patch fixes the following warning:

```
cansequence.c:232:3: warning: expression result unused [-Wunused-value]
	(unsigned char)frame.data[0]++;
	^              ~~~~~~~~~~~~~~~
```
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>