### PR TITLE
can-utils: support len8_dlc for Classical CAN frames

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -327,6 +327,15 @@ void eval_canfd(char* buf, struct timeval *date_tvp, char timestamps, int dplace
 			/* dlen is always 0 for classic CAN RTR frames
 			   but the DLC value is valid in RTR cases */
 			cf.len = dlc;
+			/* sanitize payload length value */
+			if (dlc > CAN_MAX_DLEN)
+				cf.len = CAN_MAX_DLEN;
+		}
+		/* check for extra DLC when having a Classic CAN with 8 bytes payload */
+		if ((cf.len == CAN_MAX_DLEN) && (dlc > CAN_MAX_DLEN) && (dlc <= CAN_MAX_RAW_DLC)) {
+			struct can_frame *ccf = (struct can_frame *)&cf;
+
+			ccf->len8_dlc = dlc;
 		}
 	}
 

--- a/asc2log.c
+++ b/asc2log.c
@@ -270,7 +270,7 @@ void eval_canfd(char* buf, struct timeval *date_tvp, char timestamps, int dplace
 		extra_info = " T\n";
 
 	/* don't trust ASCII content - sanitize data length */
-	if (dlen != can_dlc2len(can_len2dlc(dlen)))
+	if (dlen != can_fd_dlc2len(can_fd_len2dlc(dlen)))
 		return;
 
 	get_can_id(&cf, tmp1, 16);

--- a/candump.c
+++ b/candump.c
@@ -134,6 +134,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -D          (Don't exit if a \"detected\" can device goes down.\n");
 	fprintf(stderr, "         -d          (monitor dropped CAN frames)\n");
 	fprintf(stderr, "         -e          (dump CAN error frames in human-readable format)\n");
+	fprintf(stderr, "         -8          (display raw DLC values in {} for Classical CAN)\n");
 	fprintf(stderr, "         -x          (print extra message infos, rx/tx brs esi)\n");
 	fprintf(stderr, "         -T <msecs>  (terminate after <msecs> without any reception)\n");
 	fprintf(stderr, "\n");
@@ -255,7 +256,7 @@ int main(int argc, char **argv)
 	last_tv.tv_sec  = 0;
 	last_tv.tv_usec = 0;
 
-	while ((opt = getopt(argc, argv, "t:HciaSs:lDdxLn:r:heT:?")) != -1) {
+	while ((opt = getopt(argc, argv, "t:HciaSs:lDdxLn:r:he8T:?")) != -1) {
 		switch (opt) {
 		case 't':
 			timestamp = optarg[0];
@@ -289,6 +290,10 @@ int main(int argc, char **argv)
 
 		case 'e':
 			view |= CANLIB_VIEW_ERROR;
+			break;
+
+		case '8':
+			view |= CANLIB_VIEW_LEN8_DLC;
 			break;
 
 		case 's':
@@ -359,7 +364,7 @@ int main(int argc, char **argv)
 	}
 	
 	if (logfrmt && view) {
-		fprintf(stderr, "Log file format selected: Please disable ASCII/BINARY/SWAP options!\n");
+		fprintf(stderr, "Log file format selected: Please disable ASCII/BINARY/SWAP/RAWDLC options!\n");
 		exit(0);
 	}
 

--- a/cangen.c
+++ b/cangen.c
@@ -172,6 +172,7 @@ int main(int argc, char **argv)
 
 	struct sockaddr_can addr;
 	static struct canfd_frame frame;
+	struct can_frame *ccf = (struct can_frame *)&frame;
 	int nbytes;
 	int i;
 	struct ifreq ifr;
@@ -385,6 +386,7 @@ int main(int argc, char **argv)
 
 	while (running) {
 		frame.flags = 0;
+		ccf->len8_dlc = 0;
 
 		if (count && (--count == 0))
 			running = 0;

--- a/cangen.c
+++ b/cangen.c
@@ -114,9 +114,9 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -v            (increment verbose level for "
 		"printing sent CAN frames)\n\n");
 	fprintf(stderr, "Generation modes:\n");
-	fprintf(stderr, " 'r'         => random values (default)\n");
-	fprintf(stderr, " 'i'         => increment values\n");
-	fprintf(stderr, " <hexvalue>  => fix value using <hexvalue>\n\n");
+	fprintf(stderr, " 'r'     => random values (default)\n");
+	fprintf(stderr, " 'i'     => increment values\n");
+	fprintf(stderr, " <value> => fixed value (in hexadecimal for -I and -D)\n\n");
 	fprintf(stderr, "When incrementing the CAN data the data length code "
 		"minimum is set to 1.\n");
 	fprintf(stderr, "CAN IDs and data content are given and expected in hexadecimal values.\n\n");

--- a/cangen.c
+++ b/cangen.c
@@ -369,9 +369,17 @@ int main(int argc, char **argv)
 		/* ensure discrete CAN FD length values 0..8, 12, 16, 20, 24, 32, 64 */
 		frame.len = can_dlc2len(can_len2dlc(frame.len));
 	} else {
-		/* sanitize CAN 2.0 frame length */
-		if (frame.len > 8)
-			frame.len = 8;
+		/* sanitize Classical CAN 2.0 frame length */
+		if (len8_dlc) {
+			if (frame.len > CAN_MAX_RAW_DLC)
+				frame.len = CAN_MAX_RAW_DLC;
+
+			if (frame.len > CAN_MAX_DLEN)
+				ccf->len8_dlc = frame.len;
+		}
+
+		if (frame.len > CAN_MAX_DLEN)
+			frame.len = CAN_MAX_DLEN;
 	}
 
 	if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {

--- a/cangen.c
+++ b/cangen.c
@@ -413,8 +413,14 @@ int main(int argc, char **argv)
 				frame.len = can_dlc2len(random() & 0xF);
 			else {
 				frame.len = random() & 0xF;
-				if (frame.len & 8)
+
+				/* generate Classic CAN len8 DLCs */
+				if (frame.len > CAN_MAX_DLEN) {
+					struct can_frame *ccf = (struct can_frame *)&frame;
+
+					ccf->len8_dlc = frame.len;
 					frame.len = 8; /* for about 50% of the frames */
+				}
 			}
 		}
 

--- a/cangen.c
+++ b/cangen.c
@@ -367,7 +367,7 @@ int main(int argc, char **argv)
 		}
 
 		/* ensure discrete CAN FD length values 0..8, 12, 16, 20, 24, 32, 64 */
-		frame.len = can_dlc2len(can_len2dlc(frame.len));
+		frame.len = can_fd_dlc2len(can_fd_len2dlc(frame.len));
 	} else {
 		/* sanitize Classical CAN 2.0 frame length */
 		if (len8_dlc) {
@@ -425,7 +425,7 @@ int main(int argc, char **argv)
 		if (dlc_mode == MODE_RANDOM) {
 
 			if (canfd)
-				frame.len = can_dlc2len(random() & 0xF);
+				frame.len = can_fd_dlc2len(random() & 0xF);
 			else {
 				frame.len = random() & 0xF;
 
@@ -519,7 +519,7 @@ resend:
 			incdlc %= CAN_MAX_RAW_DLC + 1;
 
 			if (canfd && !mix)
-				frame.len = can_dlc2len(incdlc);
+				frame.len = can_fd_dlc2len(incdlc);
 			else if (len8_dlc) {
 				if (incdlc > CAN_MAX_DLEN) {
 					frame.len = CAN_MAX_DLEN;

--- a/cangen.c
+++ b/cangen.c
@@ -423,12 +423,10 @@ int main(int argc, char **argv)
 				frame.len = random() & 0xF;
 
 				if (frame.len > CAN_MAX_DLEN) {
-					if (len8_dlc) {
-						struct can_frame *ccf = (struct can_frame *)&frame;
-
-						/* generate Classic CAN len8 DLCs */
+					/* generate Classic CAN len8 DLCs? */
+					if (len8_dlc)
 						ccf->len8_dlc = frame.len;
-					}
+
 					frame.len = 8; /* for about 50% of the frames */
 				}
 			}

--- a/cangw.c
+++ b/cangw.c
@@ -256,7 +256,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "  <instruction>  is one of 'AND' 'OR' 'XOR' 'SET'\n");
 	fprintf(stderr, "  <can_frame-elements>  is _one_ or _more_ of 'I'dentifier 'L'ength 'D'ata\n");
 	fprintf(stderr, "  <can_id>  is an u32 value containing the CAN Identifier\n");
-	fprintf(stderr, "  <can_dlc>  is an u8 value containing the data length code (0 .. 15)\n");
+	fprintf(stderr, "  <can_dlc>  is an u8 value containing the data length code in hex (0 .. F)\n");
 	fprintf(stderr, "  <can_data>  is always eight(!) u8 values containing the CAN frames data\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "<MOD> is a CAN FD frame modification instruction consisting of\n");
@@ -265,7 +265,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "  <canfd_frame-elements>  is _one_ or _more_ of 'I'd 'F'lags 'L'ength 'D'ata\n");
 	fprintf(stderr, "  <can_id>  is an u32 value containing the CAN FD Identifier\n");
 	fprintf(stderr, "  <flags>  is an u8 value containing CAN FD flags (CANFD_BRS, CANFD_ESI)\n");
-	fprintf(stderr, "  <len>  is an u8 value containing the data length (0 .. 64)\n");
+	fprintf(stderr, "  <len>  is an u8 value containing the data length in hex (0 .. 40)\n");
 	fprintf(stderr, "  <can_data>  is always 64(!) u8 values containing the CAN FD frames data\n");
 	fprintf(stderr, "The max. four modifications are performed in the order AND -> OR -> XOR -> SET\n");
 	fprintf(stderr, "\n");

--- a/cangw.c
+++ b/cangw.c
@@ -240,7 +240,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "          -u <uid>  (user defined modification identifier)\n");
 	fprintf(stderr, "          -l <hops>  (limit the number of frame hops / routings)\n");
 	fprintf(stderr, "          -f <filter>  (set CAN filter)\n");
-	fprintf(stderr, "          -m <mod>  (set Classic CAN frame modifications)\n");
+	fprintf(stderr, "          -m <mod>  (set Classical CAN frame modifications)\n");
 	fprintf(stderr, "          -M <MOD>  (set CAN FD frame modifications)\n");
 	fprintf(stderr, "          -x <from_idx>:<to_idx>:<result_idx>:<init_xor_val>  (XOR checksum)\n");
 	fprintf(stderr, "          -c <from>:<to>:<result>:<init_val>:<xor_val>:<crctab[256]>  (CRC8 cs)\n");
@@ -251,12 +251,12 @@ void print_usage(char *prg)
 	fprintf(stderr, "  <can_id>:<can_mask>  (matches when <received_can_id> & mask == can_id & mask)\n");
 	fprintf(stderr, "  <can_id>~<can_mask>  (matches when <received_can_id> & mask != can_id & mask)\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "<mod> is a CAN frame modification instruction consisting of\n");
+	fprintf(stderr, "<mod> is a Classical CAN frame modification instruction consisting of\n");
 	fprintf(stderr, "<instruction>:<can_frame-elements>:<can_id>.<can_dlc>.<can_data>\n");
 	fprintf(stderr, "  <instruction>  is one of 'AND' 'OR' 'XOR' 'SET'\n");
 	fprintf(stderr, "  <can_frame-elements>  is _one_ or _more_ of 'I'dentifier 'L'ength 'D'ata\n");
 	fprintf(stderr, "  <can_id>  is an u32 value containing the CAN Identifier\n");
-	fprintf(stderr, "  <can_dlc>  is an u8 value containing the data length code (0 .. 8)\n");
+	fprintf(stderr, "  <can_dlc>  is an u8 value containing the data length code (0 .. 15)\n");
 	fprintf(stderr, "  <can_data>  is always eight(!) u8 values containing the CAN frames data\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "<MOD> is a CAN FD frame modification instruction consisting of\n");

--- a/cansend.c
+++ b/cansend.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
 		}
 
 		/* ensure discrete CAN FD length values 0..8, 12, 16, 20, 24, 32, 64 */
-		frame.len = can_dlc2len(can_len2dlc(frame.len));
+		frame.len = can_fd_dlc2len(can_fd_len2dlc(frame.len));
 	}
 
 	/* disable default receive filter on this RAW socket */

--- a/cansend.c
+++ b/cansend.c
@@ -61,8 +61,10 @@ void print_usage(char *prg)
 	fprintf(stderr, "%s - send CAN-frames via CAN_RAW sockets.\n", prg);
 	fprintf(stderr, "\nUsage: %s <device> <can_frame>.\n", prg);
 	fprintf(stderr, "\n<can_frame>:\n");
-	fprintf(stderr, " <can_id>#{data}          for 'classic' CAN 2.0 data frames\n");
-	fprintf(stderr, " <can_id>#R{len}          for 'classic' CAN 2.0 data frames\n");
+	fprintf(stderr, " <can_id>#{data}          for Classical CAN 2.0 data frames\n");
+	fprintf(stderr, " <can_id>#R{len}          for Classical CAN 2.0 data frames\n");
+	fprintf(stderr, " <can_id>#{data}_{dlc}    for Classical CAN 2.0 data frames\n");
+	fprintf(stderr, " <can_id>#R{len}_{dlc}    for Classical CAN 2.0 data frames\n");
 	fprintf(stderr, " <can_id>##<flags>{data}  for CAN FD frames\n\n");
 	fprintf(stderr, "<can_id>:\n"
 	        " 3 (SFF) or 8 (EFF) hex chars\n");
@@ -70,11 +72,13 @@ void print_usage(char *prg)
 	        " 0..8 (0..64 CAN FD) ASCII hex-values (optionally separated by '.')\n");
 	fprintf(stderr, "{len}:\n"
 		 " an optional 0..8 value as RTR frames can contain a valid dlc field\n");
+	fprintf(stderr, "_{dlc}:\n"
+		 " an optional 9..F data length code value when payload length is 8\n");
 	fprintf(stderr, "<flags>:\n"
 	        " a single ASCII Hex value (0 .. F) which defines canfd_frame.flags\n\n");
 	fprintf(stderr, "Examples:\n");
 	fprintf(stderr, "  5A1#11.2233.44556677.88 / 123#DEADBEEF / 5AA# / 123##1 / 213##311223344 /\n"
-		 "  1F334455#1122334455667788 / 123#R / 00000123#R3\n\n");
+		 "  1F334455#1122334455667788_B / 123#R / 00000123#R3 / 333#R8_E\n\n");
 }
 
 

--- a/include/linux/can.h
+++ b/include/linux/can.h
@@ -84,6 +84,7 @@ typedef __u32 can_err_mask_t;
 
 /* CAN payload length and DLC definitions according to ISO 11898-1 */
 #define CAN_MAX_DLC 8
+#define CAN_MAX_RAW_DLC 15
 #define CAN_MAX_DLEN 8
 
 /* CAN FD payload length and DLC definitions according to ISO 11898-7 */
@@ -92,22 +93,31 @@ typedef __u32 can_err_mask_t;
 
 /**
  * struct can_frame - basic CAN frame structure
- * @can_id:  CAN ID of the frame and CAN_*_FLAG flags, see canid_t definition
- * @can_dlc: frame payload length in byte (0 .. 8) aka data length code
- *           N.B. the DLC field from ISO 11898-1 Chapter 8.4.2.3 has a 1:1
- *           mapping of the 'data length code' to the real payload length
- * @__pad:   padding
- * @__res0:  reserved / padding
- * @__res1:  reserved / padding
- * @data:    CAN frame payload (up to 8 byte)
+ * @can_id:   CAN ID of the frame and CAN_*_FLAG flags, see canid_t definition
+ * @len:      CAN frame payload length in byte (0 .. 8)
+ * @can_dlc:  deprecated name for CAN frame payload length in byte (0 .. 8)
+ * @__pad:    padding
+ * @__res0:   reserved / padding
+ * @len8_dlc: optional DLC value (9 .. 15) at 8 byte payload length
+ *            len8_dlc contains values from 9 .. 15 when the payload length is
+ *            8 bytes but the DLC value (see ISO 11898-1) is greater then 8.
+ *            CAN_CTRLMODE_CC_LEN8_DLC flag has to be enabled in CAN driver.
+ * @data:     CAN frame payload (up to 8 byte)
  */
 struct can_frame {
 	canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
-	__u8    can_dlc; /* frame payload length in byte (0 .. CAN_MAX_DLEN) */
-	__u8    __pad;   /* padding */
-	__u8    __res0;  /* reserved / padding */
-	__u8    __res1;  /* reserved / padding */
-	__u8    data[CAN_MAX_DLEN] __attribute__((aligned(8)));
+	union {
+		/* CAN frame payload length in byte (0 .. CAN_MAX_DLEN)
+		 * was previously named can_dlc so we need to carry that
+		 * name for legacy support
+		 */
+		__u8 len;
+		__u8 can_dlc; /* deprecated */
+	};
+	__u8 __pad; /* padding */
+	__u8 __res0; /* reserved / padding */
+	__u8 len8_dlc; /* optional DLC for 8 byte payload length (9 .. 15) */
+	__u8 data[CAN_MAX_DLEN] __attribute__((aligned(8)));
 };
 
 /*

--- a/include/linux/can/gw.h
+++ b/include/linux/can/gw.h
@@ -98,8 +98,8 @@ enum {
 
 /* CAN frame elements that are affected by curr. 3 CAN frame modifications */
 #define CGW_MOD_ID	0x01
-#define CGW_MOD_DLC	0x02		/* contains the data length in bytes */
-#define CGW_MOD_LEN	CGW_MOD_DLC	/* CAN FD length representation */
+#define CGW_MOD_DLC	0x02		/* Classical CAN data length code */
+#define CGW_MOD_LEN	CGW_MOD_DLC	/* CAN FD (plain) data length */
 #define CGW_MOD_DATA	0x04
 #define CGW_MOD_FLAGS	0x08		/* CAN FD flags */
 

--- a/include/linux/can/netlink.h
+++ b/include/linux/can/netlink.h
@@ -100,6 +100,7 @@ struct can_ctrlmode {
 #define CAN_CTRLMODE_FD			0x20	/* CAN FD mode */
 #define CAN_CTRLMODE_PRESUME_ACK	0x40	/* Ignore missing CAN ACKs */
 #define CAN_CTRLMODE_FD_NON_ISO		0x80	/* CAN FD in non-ISO mode */
+#define CAN_CTRLMODE_CC_LEN8_DLC	0x100	/* Classic CAN DLC option */
 
 /*
  * CAN device statistics

--- a/lib.c
+++ b/lib.c
@@ -84,10 +84,10 @@ static inline void _put_id(char *buf, int end_offset, canid_t id)
 static const unsigned char dlc2len[] = {0, 1, 2, 3, 4, 5, 6, 7,
 					8, 12, 16, 20, 24, 32, 48, 64};
 
-/* get data length from can_dlc with sanitized can_dlc */
-unsigned char can_dlc2len(unsigned char can_dlc)
+/* get data length from raw data length code (DLC) */
+unsigned char can_fd_dlc2len(unsigned char dlc)
 {
-	return dlc2len[can_dlc & 0x0F];
+	return dlc2len[dlc & 0x0F];
 }
 
 static const unsigned char len2dlc[] = {0, 1, 2, 3, 4, 5, 6, 7, 8,		/* 0 - 8 */
@@ -102,7 +102,7 @@ static const unsigned char len2dlc[] = {0, 1, 2, 3, 4, 5, 6, 7, 8,		/* 0 - 8 */
 					15, 15, 15, 15, 15, 15, 15, 15};	/* 57 - 64 */
 
 /* map the sanitized data length to an appropriate data length code */
-unsigned char can_len2dlc(unsigned char len)
+unsigned char can_fd_len2dlc(unsigned char len)
 {
 	if (len > 64)
 		return 0xF;

--- a/lib.c
+++ b/lib.c
@@ -53,6 +53,7 @@
 #include "lib.h"
 
 #define CANID_DELIM '#'
+#define CC_DLC_DELIM '_'
 #define DATA_SEPERATOR '.'
 
 const char hex_asc_upper[] = "0123456789ABCDEF";
@@ -195,9 +196,19 @@ int parse_canframe(char *cs, struct canfd_frame *cf) {
 		cf->can_id |= CAN_RTR_FLAG;
 
 		/* check for optional DLC value for CAN 2.0B frames */
-		if(cs[++idx] && (tmp = asc2nibble(cs[idx])) <= CAN_MAX_DLC)
+		if(cs[++idx] && (tmp = asc2nibble(cs[idx++])) <= CAN_MAX_DLEN) {
 			cf->len = tmp;
 
+			/* check for optional raw DLC value for CAN 2.0B frames */
+			if ((tmp == CAN_MAX_DLEN) && (cs[idx++] == CC_DLC_DELIM)) {
+				tmp = asc2nibble(cs[idx]);
+				if ((tmp > CAN_MAX_DLEN) && (tmp <= CAN_MAX_RAW_DLC)) {
+					struct can_frame *ccf = (struct can_frame *)cf;
+
+					ccf->len8_dlc = tmp;
+				}
+			}
+		}
 		return ret;
 	}
 
@@ -231,6 +242,17 @@ int parse_canframe(char *cs, struct canfd_frame *cf) {
 		dlen++;
 	}
 	cf->len = dlen;
+
+	/* check for extra DLC when having a Classic CAN with 8 bytes payload */
+	if ((maxdlen == CAN_MAX_DLEN) && (dlen == CAN_MAX_DLEN) && (cs[idx++] == CC_DLC_DELIM)) {
+		unsigned char dlc = asc2nibble(cs[idx]);
+
+		if ((dlc > CAN_MAX_DLEN) && (dlc <= CAN_MAX_RAW_DLC)) {
+			struct can_frame *ccf = (struct can_frame *)cf;
+
+			ccf->len8_dlc = dlc;
+		}
+	}
 
 	return ret;
 }
@@ -270,8 +292,19 @@ void sprint_canframe(char *buf , struct canfd_frame *cf, int sep, int maxdlen) {
 	if (maxdlen == CAN_MAX_DLEN && cf->can_id & CAN_RTR_FLAG) {
 		buf[offset++] = 'R';
 		/* print a given CAN 2.0B DLC if it's not zero */
-		if (cf->len && cf->len <= CAN_MAX_DLC)
+		if (cf->len && cf->len <= CAN_MAX_DLEN) {
 			buf[offset++] = hex_asc_upper_lo(cf->len);
+
+			/* check for optional raw DLC value for CAN 2.0B frames */
+			if (cf->len == CAN_MAX_DLEN) {
+				struct can_frame *ccf = (struct can_frame *)cf;
+
+				if ((ccf->len8_dlc > CAN_MAX_DLEN) && (ccf->len8_dlc <= CAN_MAX_RAW_DLC)) {
+					buf[offset++] = CC_DLC_DELIM;
+					buf[offset++] = hex_asc_upper_lo(ccf->len8_dlc);
+				}
+			}
+		}
 
 		buf[offset] = 0;
 		return;
@@ -290,6 +323,17 @@ void sprint_canframe(char *buf , struct canfd_frame *cf, int sep, int maxdlen) {
 		offset += 2;
 		if (sep && (i+1 < len))
 			buf[offset++] = '.';
+	}
+
+	/* check for extra DLC when having a Classic CAN with 8 bytes payload */
+	if ((maxdlen == CAN_MAX_DLEN) && (len == CAN_MAX_DLEN)) {
+		struct can_frame *ccf = (struct can_frame *)cf;
+		unsigned char dlc = ccf->len8_dlc;
+
+		if ((dlc > CAN_MAX_DLEN) && (dlc <= CAN_MAX_RAW_DLC)) {
+			buf[offset++] = CC_DLC_DELIM;
+			buf[offset++] = hex_asc_upper_lo(dlc);
+		}
 	}
 
 	buf[offset] = 0;

--- a/lib.h
+++ b/lib.h
@@ -61,11 +61,11 @@
 
 /* CAN DLC to real data length conversion helpers especially for CAN FD */
 
-/* get data length from can_dlc with sanitized can_dlc */
-unsigned char can_dlc2len(unsigned char can_dlc);
+/* get data length from raw data length code (DLC) */
+unsigned char can_fd_dlc2len(unsigned char dlc);
 
 /* map the sanitized data length to an appropriate data length code */
-unsigned char can_len2dlc(unsigned char len);
+unsigned char can_fd_len2dlc(unsigned char len);
 
 unsigned char asc2nibble(char c);
 /*

--- a/lib.h
+++ b/lib.h
@@ -182,6 +182,7 @@ void sprint_canframe(char *buf , struct canfd_frame *cf, int sep, int maxdlen);
 #define CANLIB_VIEW_SWAP	0x4
 #define CANLIB_VIEW_ERROR	0x8
 #define CANLIB_VIEW_INDENT_SFF	0x10
+#define CANLIB_VIEW_LEN8_DLC	0x20
 
 #define SWAP_DELIMITER '`'
 
@@ -194,11 +195,12 @@ void sprint_long_canframe(char *buf , struct canfd_frame *cf, int view, int maxd
  * maxdlen = 8 -> CAN2.0 frame (aka Classical CAN)
  * maxdlen = 64 -> CAN FD frame
  *
- * 12345678   [3]  11 22 33 -> extended CAN-Id = 0x12345678, dlc = 3, data
+ * 12345678   [3]  11 22 33 -> extended CAN-Id = 0x12345678, len = 3, data
  * 12345678   [0]  remote request -> extended CAN-Id = 0x12345678, RTR
  * 14B0DC51   [8]  4A 94 E8 2A EC 58 55 62   'J..*.XUb' -> (with ASCII output)
+ * 321   {B}  11 22 33 44 55 66 77 88 -> Classical CAN with raw '{DLC}' value B
  * 20001111   [7]  C6 23 7B 32 69 98 3C      ERRORFRAME -> (CAN_ERR_FLAG set)
- * 12345678  [03]  11 22 33 -> CAN FD with extended CAN-Id = 0x12345678, dlc = 3
+ * 12345678  [03]  11 22 33 -> CAN FD with extended CAN-Id = 0x12345678, len = 3
  *
  * 123   [3]  11 22 33         -> CANLIB_VIEW_INDENT_SFF == 0
  *      123   [3]  11 22 33    -> CANLIB_VIEW_INDENT_SFF == set
@@ -208,7 +210,7 @@ void sprint_long_canframe(char *buf , struct canfd_frame *cf, int view, int maxd
  * // CAN FD frame with eol to STDOUT
  * fprint_long_canframe(stdout, &frame, "\n", 0, CANFD_MAX_DLEN);
  *
- * // CAN 2.0 frame without eol to STDERR
+ * // Classical CAN 2.0 frame without eol to STDERR
  * fprint_long_canframe(stderr, &frame, NULL, 0, CAN_MAX_DLEN);
  *
  */

--- a/lib.h
+++ b/lib.h
@@ -99,10 +99,11 @@ int parse_canframe(char *cs, struct canfd_frame *cf);
 /*
  * Transfers a valid ASCII string describing a CAN frame into struct canfd_frame.
  *
- * CAN 2.0 frames
- * - string layout <can_id>#{R{len}|data}
+ * CAN 2.0 frames (aka Classical CAN)
+ * - string layout <can_id>#{R{len}|data}{_len8_dlc}
  * - {data} has 0 to 8 hex-values that can (optionally) be separated by '.'
  * - {len} can take values from 0 to 8 and can be omitted if zero
+ * - {_len8_dlc} can take hex values from '_9' to '_F' when len is CAN_MAX_DLEN
  * - return value on successful parsing: CAN_MTU
  *
  * CAN FD frames
@@ -124,10 +125,12 @@ int parse_canframe(char *cs, struct canfd_frame *cf);
  * 123#R -> standard CAN-Id = 0x123, len = 0, RTR-frame
  * 123#R0 -> standard CAN-Id = 0x123, len = 0, RTR-frame
  * 123#R7 -> standard CAN-Id = 0x123, len = 7, RTR-frame
+ * 123#R8_9 -> standard CAN-Id = 0x123, len = 8, dlc = 9, RTR-frame
  * 7A1#r -> standard CAN-Id = 0x7A1, len = 0, RTR-frame
  *
  * 123#00 -> standard CAN-Id = 0x123, len = 1, data[0] = 0x00
  * 123#1122334455667788 -> standard CAN-Id = 0x123, len = 8
+ * 123#1122334455667788_E -> standard CAN-Id = 0x123, len = 8, dlc = 14
  * 123#11.22.33.44.55.66.77.88 -> standard CAN-Id = 0x123, len = 8
  * 123#11.2233.44556677.88 -> standard CAN-Id = 0x123, len = 8
  * 32345678#112233 -> error frame with CAN_ERR_FLAG (0x2000000) set
@@ -155,10 +158,11 @@ void sprint_canframe(char *buf , struct canfd_frame *cf, int sep, int maxdlen);
  * The CAN data[] is separated by '.' when sep != 0.
  *
  * The type of the CAN frame (CAN 2.0 / CAN FD) is specified by maxdlen:
- * maxdlen = 8 -> CAN2.0 frame
+ * maxdlen = 8 -> CAN2.0 frame (aka Classical CAN)
  * maxdlen = 64 -> CAN FD frame
  *
  * 12345678#112233 -> extended CAN-Id = 0x12345678, len = 3, data, sep = 0
+ * 123#1122334455667788_E -> standard CAN-Id = 0x123, len = 8, dlc = 14, data, sep = 0
  * 12345678#R -> extended CAN-Id = 0x12345678, RTR, len = 0
  * 12345678#R5 -> extended CAN-Id = 0x12345678, RTR, len = 5
  * 123#11.22.33.44.55.66.77.88 -> standard CAN-Id = 0x123, dlc = 8, sep = 1
@@ -187,7 +191,7 @@ void sprint_long_canframe(char *buf , struct canfd_frame *cf, int view, int maxd
  * Creates a CAN frame hexadecimal output in user readable format.
  *
  * The type of the CAN frame (CAN 2.0 / CAN FD) is specified by maxdlen:
- * maxdlen = 8 -> CAN2.0 frame
+ * maxdlen = 8 -> CAN2.0 frame (aka Classical CAN)
  * maxdlen = 64 -> CAN FD frame
  *
  * 12345678   [3]  11 22 33 -> extended CAN-Id = 0x12345678, dlc = 3, data

--- a/log2asc.c
+++ b/log2asc.c
@@ -116,7 +116,7 @@ void canfd_asc(struct canfd_frame *cf, int devno, int mtu, char *extra_info, FIL
 	char *dir = "Rx";
 	unsigned int flags = 0;
 	unsigned int dlen = cf->len;
-	unsigned int dlc = can_len2dlc(dlen);
+	unsigned int dlc = can_fd_len2dlc(dlen);
 
 	/* relevant flags in Flags field */
 #define ASC_F_RTR 0x00000010


### PR DESCRIPTION
This is the patch set that has been developed to support DLC values from 9 .. 15 for Classical CAN capable CAN adapters.