### PR TITLE
docs: fix simple typo, cought -> caught

### DIFF
--- a/canlogserver.c
+++ b/canlogserver.c
@@ -162,7 +162,7 @@ void childdied(int i)
 }
 
 /*
- * This is a Signalhandler for a cought SIGTERM
+ * This is a Signalhandler for a caught SIGTERM
  */
 void shutdown_gra(int i)
 {


### PR DESCRIPTION
There is a small typo in canlogserver.c.

Should read `caught` rather than `cought`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md