### PR TITLE
cangen: add possibility to generate random ID odd/even

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -72,6 +72,8 @@
 #define MODE_RANDOM	0
 #define MODE_INCREMENT	1
 #define MODE_FIX	2
+#define MODE_RANDOM_EVEN	3
+#define MODE_RANDOM_ODD	4
 
 extern int optind, opterr, optopt;
 
@@ -115,6 +117,8 @@ void print_usage(char *prg)
 		"printing sent CAN frames)\n\n");
 	fprintf(stderr, "Generation modes:\n");
 	fprintf(stderr, " 'r'     => random values (default)\n");
+	fprintf(stderr, " 'e'     => random values, even ID\n");
+	fprintf(stderr, " 'o'     => random values, odd ID\n");
 	fprintf(stderr, " 'i'     => increment values\n");
 	fprintf(stderr, " <value> => fixed value (in hexadecimal for -I and -D)\n\n");
 	fprintf(stderr, "When incrementing the CAN data the data length code "
@@ -227,6 +231,10 @@ int main(int argc, char **argv)
 				id_mode = MODE_RANDOM;
 			} else if (optarg[0] == 'i') {
 				id_mode = MODE_INCREMENT;
+			} else if (optarg[0] == 'e') {
+				id_mode = MODE_RANDOM_EVEN;
+			} else if (optarg[0] == 'o') {
+				id_mode = MODE_RANDOM_ODD;
 			} else {
 				id_mode = MODE_FIX;
 				frame.can_id = strtoul(optarg, NULL, 16);
@@ -412,6 +420,10 @@ int main(int argc, char **argv)
 
 		if (id_mode == MODE_RANDOM)
 			frame.can_id = random();
+		else if (id_mode == MODE_RANDOM_EVEN)
+			frame.can_id = random() & ~0x1;
+		else if (id_mode == MODE_RANDOM_ODD)
+			frame.can_id = random() | 0x1;
 
 		if (extended) {
 			frame.can_id &= CAN_EFF_MASK;


### PR DESCRIPTION
Use this for stress testing, when sending with two CAN controllers on the same CAN bus to avoid broken CAN frames due sending the same CAN-id.
