### PR TITLE
Clarify that the mcp251x uses half of the external OSC clock as the base clock

### DIFF
--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -363,9 +363,9 @@ static struct calc_bittiming_const can_calc_consts[] = {
 		},
 		.ref_clk = {
 			/* The mcp251x uses half of the external OSC clock as the base clock */
-			{ .clk =  8000000 / 2, },
-			{ .clk = 16000000 / 2, },
-			{ .clk = 20000000 / 2, },
+			{ .clk =  8000000 / 2, .name = "8 MHz OSC" },
+			{ .clk = 16000000 / 2, .name = "16 MHz OSC" },
+			{ .clk = 20000000 / 2, .name = "20 MHz OSC" },
 		},
 		.printf_btr = printf_btr_mcp251x,
 	}, {

--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -362,8 +362,9 @@ static struct calc_bittiming_const can_calc_consts[] = {
 			.brp_inc = 1,
 		},
 		.ref_clk = {
-			{ .clk =  8000000, },
-			{ .clk = 10000000, },
+			/* The mcp251x uses half of the external OSC clock as the base clock */
+			{ .clk = 16000000 / 2, },
+			{ .clk = 20000000 / 2, },
 		},
 		.printf_btr = printf_btr_mcp251x,
 	}, {

--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -363,6 +363,7 @@ static struct calc_bittiming_const can_calc_consts[] = {
 		},
 		.ref_clk = {
 			/* The mcp251x uses half of the external OSC clock as the base clock */
+			{ .clk =  8000000 / 2, },
 			{ .clk = 16000000 / 2, },
 			{ .clk = 20000000 / 2, },
 		},


### PR DESCRIPTION
This comment would have saved me a lot of time, when I was trying to figure out why the generated BRP in the table was twice of what it should be according to the datasheet.

I'm using a device with a 8 MHz crystal, thus the version of this tool that gets installed in Ubuntu 20.04 does not have the following commit: https://github.com/linux-can/can-utils/commit/3fc6c05ce244929b645ffd89d4e33a3511f6880d, which made it pretty confusing.