### PR TITLE
asc2log: Correct usec overflow handling

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -119,7 +119,7 @@ void calc_tv(struct timeval *tv, struct timeval *read_tv,
 		tv->tv_usec += read_tv->tv_usec;
 	}
 
-	if (tv->tv_usec > 1000000) {
+	if (tv->tv_usec >= 1000000) {
 		tv->tv_usec -= 1000000;
 		tv->tv_sec++;
 	}


### PR DESCRIPTION
This commit fixes this sort of lines
(1614188635.1000000) can1 4A8##28001E9A318ACC0 R
to become this
(1614188636.000000) can1 4A8##28001E9A318ACC0 R

Canplayer was barfing about the incorrect lines.