### PR TITLE
Circular buffer file output

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -135,7 +135,7 @@ static void print_usage(char *prg)
 	fprintf(stderr, "         -S          (swap byte order in printed CAN data[] - marked with '%c' )\n", SWAP_DELIMITER);
 	fprintf(stderr, "         -s <level>  (silent mode - %d: off (default) %d: animation %d: silent)\n", SILENT_OFF, SILENT_ANI, SILENT_ON);
 	fprintf(stderr, "         -l          (log CAN-frames into file. Sets '-s %d' by default)\n", SILENT_ON);
-	fprintf(stderr, "         -b <count>  (log CAN-frames into a ring buffer file of at most <count> CAN frames)\n");
+	fprintf(stderr, "         -b <count>  (similar to '-l', but using a ring buffer file of at most <count> CAN frames)\n");
 	fprintf(stderr, "         -L          (use log file format on stdout)\n");
 	fprintf(stderr, "         -n <count>  (terminate after reception of <count> CAN frames)\n");
 	fprintf(stderr, "         -r <size>   (set socket receive buffer to <size>)\n");

--- a/candump.c
+++ b/candump.c
@@ -315,9 +315,9 @@ int main(int argc, char **argv)
 	struct timeval tv, last_tv;
 	int timeout_ms = -1; /* default to no timeout */
 	FILE *logfile = NULL;
-  int buffer_length = 0; /*  number of entries to store in ring buffer */
-  int buffer_index = 0;
-  unsigned char circular = 0;
+	int buffer_length = 0; /*	 number of entries to store in ring buffer */
+	int buffer_index = 0;
+	unsigned char circular = 0;
 
 
 	signal(SIGTERM, sigterm);
@@ -379,10 +379,10 @@ int main(int argc, char **argv)
 			}
 			break;
 
-    case 'b':
-      buffer_length = atoi(optarg);
-      circular = 1;
-      break;
+		case 'b':
+			buffer_length = atoi(optarg);
+			circular = 1;
+			break;
 
 		case 'l':
 			log = 1;
@@ -445,15 +445,15 @@ int main(int argc, char **argv)
 		exit(0);
 	}
 
-  if (circular && log){
-      fprintf(stderr, "Circular buffer and file output can't both be selected: please use either option in isolation\n");
-      exit(0);
-  }
+	if (circular && log){
+			fprintf(stderr, "Circular buffer and file output can't both be selected: please use either option in isolation\n");
+			exit(0);
+	}
 
-  if (circular && logfrmt){
-      fprintf(stderr, "Circular buffer and file format output can't both be selected: please use either option in isolation\n");
-      exit(0);
-  }
+	if (circular && logfrmt){
+			fprintf(stderr, "Circular buffer and file format output can't both be selected: please use either option in isolation\n");
+			exit(0);
+	}
 
 	if (silent == SILENT_INI) {
 		if (log || circular) {
@@ -693,10 +693,10 @@ int main(int argc, char **argv)
 		if (silent != SILENT_ON)
 			fprintf(stderr, "Warning: Console output active while logging!\n");
 
-    if(circular)
-        fprintf(stderr, "Enabling Circular Logfile (max %d data points) '%s'\n", buffer_length, fname);
-    else
-        fprintf(stderr, "Enabling Logfile '%s'\n", fname);
+		if(circular)
+				fprintf(stderr, "Enabling Circular Logfile (max %d data points) '%s'\n", buffer_length, fname);
+		else
+				fprintf(stderr, "Enabling Logfile '%s'\n", fname);
 
 		logfile = fopen(fname, circular? "w+" : "w");
 		if (!logfile) {
@@ -804,30 +804,30 @@ int main(int argc, char **argv)
 					extra_info = " R";
 			}
 
-      if (circular) {
-          char output[CL_CFSZ + TIMESTAMPSZ];
-          char buf[CL_CFSZ]; /* max length */
-          char ts_buf[TIMESTAMPSZ];
+			if (circular) {
+					char output[CL_CFSZ + TIMESTAMPSZ];
+					char buf[CL_CFSZ]; /* max length */
+					char ts_buf[TIMESTAMPSZ];
 
-          sprint_timestamp(logtimestamp, &tv, &last_tv, ts_buf);
-          /* log CAN frame with absolute timestamp & device */
-          sprint_canframe(buf, &frame, 0, maxdlen);
+					sprint_timestamp(logtimestamp, &tv, &last_tv, ts_buf);
+					/* log CAN frame with absolute timestamp & device */
+					sprint_canframe(buf, &frame, 0, maxdlen);
 
-          /*  force a payload size of exactly 25: this corresponds to
-              8 characters for an extended can-id, 1 character for the hash
-              and 16 character of payload (maximum allowable size)
-           */
-          snprintf(output, CL_CFSZ + TIMESTAMPSZ, "%s%*s %-25.25s%s\n", ts_buf,
-                   max_devname_len, devname[idx], buf,
-                   extra_info);
+					/*	force a payload size of exactly 25: this corresponds to
+							8 characters for an extended can-id, 1 character for the hash
+							and 16 character of payload (maximum allowable size)
+					 */
+					snprintf(output, CL_CFSZ + TIMESTAMPSZ, "%s%*s %-25.25s%s\n", ts_buf,
+									 max_devname_len, devname[idx], buf,
+									 extra_info);
 
-          /*  if the buffer index has grown past the desired count, seek to head of file and reset counter */
-          if(++buffer_index >= buffer_length){
-              rewind(logfile);
-              buffer_index = 0;
-          }
-          fprintf(logfile, output);
-      }
+					/*	if the buffer index has grown past the desired count, seek to head of file and reset counter */
+					if(++buffer_index >= buffer_length){
+							rewind(logfile);
+							buffer_index = 0;
+					}
+					fprintf(logfile, output);
+			}
 
 			if (log) {
 				char buf[CL_CFSZ]; /* max length */

--- a/candump.c
+++ b/candump.c
@@ -317,7 +317,6 @@ int main(int argc, char **argv)
 	FILE *logfile = NULL;
   int buffer_length = 0; /*  number of entries to store in ring buffer */
   int buffer_index = 0;
-  int line_length = 0; /*  cached length of entries  */
   unsigned char circular = 0;
 
 
@@ -806,7 +805,7 @@ int main(int argc, char **argv)
 			}
 
       if (circular) {
-          char output[1024];
+          char output[CL_CFSZ + TIMESTAMPSZ];
           char buf[CL_CFSZ]; /* max length */
           char ts_buf[TIMESTAMPSZ];
 
@@ -818,13 +817,9 @@ int main(int argc, char **argv)
               8 characters for an extended can-id, 1 character for the hash
               and 16 character of payload (maximum allowable size)
            */
-          int len = snprintf(output, 1024, "%s%*s %-25.25s%s\n", ts_buf,
-                             max_devname_len, devname[idx], buf,
-                             extra_info);
-
-          /*  store the formatted size of the finished output string  */
-          if(line_length == 0)
-              line_length = len;
+          snprintf(output, CL_CFSZ + TIMESTAMPSZ, "%s%*s %-25.25s%s\n", ts_buf,
+                   max_devname_len, devname[idx], buf,
+                   extra_info);
 
           /*  if the buffer index has grown past the desired count, seek to head of file and reset counter */
           if(++buffer_index >= buffer_length){


### PR DESCRIPTION
Circular buffer implementation as per #289.

Sometimes the need arises to log accidents like a dash-cam. High bandwidth CANbus logging becomes expensive from storage a standpoint especially on embedded devices.

This feature allows for ring-buffer type logging where a fixed number of "most recent" entries is constantly on file and ready to be stored in the event of a failure for forensic analysis.

This implementation relies heavily on the existing `log` code-path and as such introduces a (perhaps undesirable) coupling. However, it also avoided trying to make the actual `log` output code-path (line 832) be conditional, and instead outputs in a dedicated code block on line 807.