### PR TITLE
Add CANFD_FDF flag

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -315,6 +315,7 @@ void eval_canfd(char* buf, struct timeval *date_tvp, char timestamps, int dplace
 
 	if (flags & ASC_F_FDF) {
 		dlen = CANFD_MAX_DLEN;
+		cf.flags |= CANFD_FDF;
 		if (flags & ASC_F_BRS)
 			cf.flags |= CANFD_BRS;
 		if (flags & ASC_F_ESI)

--- a/cangen.c
+++ b/cangen.c
@@ -409,6 +409,7 @@ int main(int argc, char **argv)
 		if (canfd){
 			mtu = CANFD_MTU;
 			maxdlen = CANFD_MAX_DLEN;
+			frame.flags |= CANFD_FDF;
 			if (brs)
 				frame.flags |= CANFD_BRS;
 			if (esi)

--- a/cangw.c
+++ b/cangw.c
@@ -264,7 +264,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "  <instruction>  is one of 'AND' 'OR' 'XOR' 'SET'\n");
 	fprintf(stderr, "  <canfd_frame-elements>  is _one_ or _more_ of 'I'd 'F'lags 'L'ength 'D'ata\n");
 	fprintf(stderr, "  <can_id>  is an u32 value containing the CAN FD Identifier\n");
-	fprintf(stderr, "  <flags>  is an u8 value containing CAN FD flags (CANFD_BRS, CANFD_ESI)\n");
+	fprintf(stderr, "  <flags>  is an u8 value containing CAN FD flags (CANFD_BRS, CANFD_ESI, CANFD_FDF)\n");
 	fprintf(stderr, "  <len>  is an u8 value containing the data length in hex (0 .. 40)\n");
 	fprintf(stderr, "  <can_data>  is always 64(!) u8 values containing the CAN FD frames data\n");
 	fprintf(stderr, "The max. four modifications are performed in the order AND -> OR -> XOR -> SET\n");

--- a/include/linux/can.h
+++ b/include/linux/can.h
@@ -135,9 +135,18 @@ struct can_frame {
  * controller only the CANFD_BRS bit is relevant for real CAN controllers when
  * building a CAN FD frame for transmission. Setting the CANFD_ESI bit can make
  * sense for virtual CAN interfaces to test applications with echoed frames.
+ *
+ * The struct can_frame and struct canfd_frame intentionaly share the same
+ * layout to be able to write CAN frame content into a CAN FD frame structure.
+ * When this is done the former differentiation via CAN_MTU / CANFD_MTU gets
+ * lost. CANFD_FDF allows programmers to mark CAN FD frames in the case of
+ * using struct canfd_frame for mixed CAN / CAN FD content (dual use).
+ * N.B. the Kernel APIs do NOT provide mixed CAN / CAN FD content inside of
+ * struct canfd_frame therefore the CANFD_FDF flag is disregarded by Linux.
  */
 #define CANFD_BRS 0x01 /* bit rate switch (second bitrate for payload data) */
 #define CANFD_ESI 0x02 /* error state indicator of the transmitting node */
+#define CANFD_FDF 0x04 /* mark CAN FD for dual use of struct canfd_frame */
 
 /**
  * struct canfd_frame - CAN flexible data rate frame structure

--- a/include/linux/can.h
+++ b/include/linux/can.h
@@ -114,14 +114,14 @@ struct can_frame {
 		__u8 len;
 		__u8 can_dlc; /* deprecated */
 	};
-	__u8 __pad; /* padding */
+	__u8 flags; /* additional flags */
 	__u8 __res0; /* reserved / padding */
 	__u8 len8_dlc; /* optional DLC for 8 byte payload length (9 .. 15) */
 	__u8 data[CAN_MAX_DLEN] __attribute__((aligned(8)));
 };
 
 /*
- * defined bits for canfd_frame.flags
+ * defined bits for canfd_frame.flags and can_frame.flags
  *
  * The use of struct canfd_frame implies the Extended Data Length (EDL) bit to
  * be set in the CAN frame bitstream on the wire. The EDL bit switch turns


### PR DESCRIPTION
First commit was taken as is from @hartkopp https://lore.kernel.org/linux-can/20170411134343.3089-1-socketcan@hartkopp.net/ so he was marked as author.

Second commit is the result of agreement on having flags for both CAN and CAN-FD as per https://lore.kernel.org/linux-can/20210503100810.cacbmdfmpjipgoka@pengutronix.de/