### PR TITLE
candump: fix epoll_wait() returning -1, errno == -EINTR

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -690,10 +690,10 @@ int main(int argc, char **argv)
 	msg.msg_control = &ctrlmsg;
 
 	while (running) {
-
-		if ((num_events = epoll_wait(fd_epoll, events_pending, currmax, timeout_ms)) <= 0) {
-			//perror("epoll_wait");
-			running = 0;
+		num_events = epoll_wait(fd_epoll, events_pending, currmax, timeout_ms);
+		if (num_events == -1) {
+			if (errno != EINTR)
+				running = 0;
 			continue;
 		}
 


### PR DESCRIPTION
-EINTR is not an error, just restart the syscall.

Fixes: 639498bc801a ("candump: use epoll_wait() instead of select()")
Link: https://github.com/linux-can/can-utils/issues/296
Reported-by: Joakim Zhang <qiangqing.zhang@nxp.com>
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>