### PR TITLE
[V2] canbusload with FD support

### DIFF
--- a/canframelen.h
+++ b/canframelen.h
@@ -80,5 +80,6 @@ enum cfl_mode {
  * Mode determines how to deal with stuffed bits.
  */
 unsigned can_frame_length(struct canfd_frame *frame, enum cfl_mode mode, int mtu);
+unsigned can_frame_dbitrate_length(struct canfd_frame *frame, enum cfl_mode mode, int mtu);
 
 #endif


### PR DESCRIPTION
This MR adds (limited) CANFD support to the canbusload program.

1. set the socket in CANFD mode to receive all (up to 64) databytes
2. count the databits for BRS frames against the data bittiming