### PR TITLE
[v2] more chips bittiming

### DIFF
--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -289,6 +289,24 @@ static void printf_btr_bxcan(struct can_bittiming *bt, bool hdr)
 	}
 }
 
+static void printf_btr_c_can(struct can_bittiming *bt, bool hdr)
+{
+	if (hdr) {
+		printf("%s", "  BTR  BRPEXT");
+	} else {
+		uint32_t btr;
+		uint32_t brpext;
+
+		btr = (((bt->brp -1) & 0x3f) << 0) |
+			(((bt->sjw -1) & 0x3) << 6) |
+			(((bt->prop_seg + bt->phase_seg1 -1) & 0xf) << 8) |
+			(((bt->phase_seg2 -1) & 0x7) << 12);
+		brpext = ((bt->brp -1) >> 6) & 0xf;
+
+		printf("0x%04x 0x%04x", btr, brpext);
+	}
+}
+
 static struct calc_bittiming_const can_calc_consts[] = {
 	{
 		.bittiming_const = {
@@ -449,6 +467,22 @@ static struct calc_bittiming_const can_calc_consts[] = {
 			{ .clk = 48000000, },
 		},
 		.printf_btr = printf_btr_bxcan,
+	}, {
+		.bittiming_const = {
+			.name = "c_can",
+			.tseg1_min = 2,
+			.tseg1_max = 16,
+			.tseg2_min = 1,
+			.tseg2_max = 8,
+			.sjw_max = 4,
+			.brp_min = 1,
+			.brp_max = 1024,
+			.brp_inc = 1,
+		},
+		.ref_clk = {
+			{ .clk = 24000000, },
+		},
+		.printf_btr = printf_btr_c_can,
 	},
 };
 

--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -307,6 +307,23 @@ static void printf_btr_c_can(struct can_bittiming *bt, bool hdr)
 	}
 }
 
+static void printf_btr_mcan(struct can_bittiming *bt, bool hdr)
+{
+	if (hdr) {
+		printf("%10s", "NBTP");
+	} else {
+		uint32_t nbtp;
+
+
+		nbtp = (((bt->brp -1) & 0x1ff) << 16) |
+			(((bt->sjw -1) & 0x7f) << 25) |
+			(((bt->prop_seg + bt->phase_seg1 -1) & 0xff) << 8) |
+			(((bt->phase_seg2 -1) & 0x7f) << 0);
+
+		printf("0x%08x", nbtp);
+	}
+}
+
 static struct calc_bittiming_const can_calc_consts[] = {
 	{
 		.bittiming_const = {
@@ -483,6 +500,22 @@ static struct calc_bittiming_const can_calc_consts[] = {
 			{ .clk = 24000000, },
 		},
 		.printf_btr = printf_btr_c_can,
+	}, {
+		.bittiming_const = {
+			.name = "mcan-v3.1+",
+			.tseg1_min = 2,
+			.tseg1_max = 256,
+			.tseg2_min = 2,
+			.tseg2_max = 128,
+			.sjw_max = 128,
+			.brp_min = 1,
+			.brp_max = 512,
+			.brp_inc = 1,
+		},
+		.ref_clk = {
+			{ .clk = 40000000, },
+		},
+		.printf_btr = printf_btr_mcan,
 	},
 };
 

--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -273,6 +273,22 @@ static void printf_btr_rcar_can(struct can_bittiming *bt, bool hdr)
 	}
 }
 
+static void printf_btr_bxcan(struct can_bittiming *bt, bool hdr)
+{
+	if (hdr) {
+		printf("%10s", "CAN_BTR");
+	} else {
+		uint32_t btr;
+
+		btr = (((bt->brp -1) & 0x3ff) << 0) |
+			(((bt->prop_seg + bt->phase_seg1 -1) & 0xf) << 16) |
+			(((bt->phase_seg2 -1) & 0x7) << 20) |
+			(((bt->sjw -1) & 0x3) << 24);
+
+		printf("0x%08x", btr);
+	}
+}
+
 static struct calc_bittiming_const can_calc_consts[] = {
 	{
 		.bittiming_const = {
@@ -417,6 +433,22 @@ static struct calc_bittiming_const can_calc_consts[] = {
 			{ .clk = 65000000, },
 		},
 		.printf_btr = printf_btr_rcar_can,
+	}, {
+		.bittiming_const = {
+			.name = "bxcan",
+			.tseg1_min = 1,
+			.tseg1_max = 16,
+			.tseg2_min = 1,
+			.tseg2_max = 8,
+			.sjw_max = 4,
+			.brp_min = 1,
+			.brp_max = 1024,
+			.brp_inc = 1,
+		},
+		.ref_clk = {
+			{ .clk = 48000000, },
+		},
+		.printf_btr = printf_btr_bxcan,
 	},
 };
 


### PR DESCRIPTION
This request adds can-calc-bittiming support for

* STM32 bxCAN
* C_CAN
* MCAN >=v3.1