### PR TITLE
can-calc-bit-timing: can_fixup_bittiming(): change type of tseg1 and alltseg to unsigned int

### DIFF
--- a/can-calc-bit-timing.c
+++ b/can-calc-bit-timing.c
@@ -695,7 +695,7 @@ static int can_fixup_bittiming(struct net_device *dev, struct can_bittiming *bt,
 			       const struct can_bittiming_const *btc)
 {
 	struct can_priv *priv = netdev_priv(dev);
-	int tseg1, alltseg;
+	unsigned int tseg1, alltseg;
 	u64 brp64, v64;
 
 	tseg1 = bt->prop_seg + bt->phase_seg1;


### PR DESCRIPTION
All timing calculation is done with unsigned integers, so change type
of tseg1 and alltseg to unsigned int, too.

Link: https://lore.kernel.org/all/20211013130653.1513627-1-mkl@pengutronix.de
Link: https://github.com/linux-can/can-utils/pull/314
Reported-by: Gary Bisson <bisson.gary@gmail.com>
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>