### PR TITLE
j1939cat: properly fix printf format string to work both on 32 and 64 bit systems

### DIFF
--- a/j1939cat.c
+++ b/j1939cat.c
@@ -265,7 +265,7 @@ static int j1939cat_extract_serr(struct j1939cat_priv *priv)
 		case J1939_EE_INFO_RX_RTS:
 			stats->tskey = serr->ee_data;
 			j1939cat_print_timestamp(priv, "RX RTS", &tss->ts[0]);
-			fprintf(stderr, "  total size: %u, pgn=0x%05x, sa=0x%02x, da=0x%02x src_name=0x%08lx, dst_name=0x%08lx)\n",
+			fprintf(stderr, "  total size: %u, pgn=0x%05x, sa=0x%02x, da=0x%02x src_name=0x%08" PRIx64 ", dst_name=0x%08" PRIx64 ")\n",
 				stats->total, stats->pgn,  stats->sa, stats->da,
 				stats->src_name, stats->dst_name);
 			priv->last_dpo = -1;


### PR DESCRIPTION
Fixes: 7b8457ce9f79 ("j1939cat: fix long long unsigned int warning in x_name printf")
Fixes: cc155d2f63da ("j1939cat: make use of new RX UAPI")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>