### PR TITLE
mcp251xfd: add missing libgen.h header

### DIFF
--- a/mcp251xfd/mcp251xfd-main.c
+++ b/mcp251xfd/mcp251xfd-main.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <getopt.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Needed for the basename() function under musl.