### PR TITLE
testj1939: fix 64-bit types for some platforms

### DIFF
--- a/libj1939.h
+++ b/libj1939.h
@@ -10,6 +10,8 @@
  * as published by the Free Software Foundation
  */
 
+#define __SANE_USERSPACE_TYPES__ // needed for some platforms to get proper 64-bit types
+
 #include <sys/socket.h>
 #include <linux/can.h>
 #include <linux/can/j1939.h>

--- a/testj1939.c
+++ b/testj1939.c
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
 			int i;
 
 			if (todo_names && peername.can_addr.j1939.name)
-				printf("%016" PRIx64 " ", peername.can_addr.j1939.name);
+				printf("%016llx ", peername.can_addr.j1939.name);
 			printf("%02x %05x:", peername.can_addr.j1939.addr,
 					peername.can_addr.j1939.pgn);
 			for (i = 0, j = 0; i < ret; ++i, j++) {


### PR DESCRIPTION
Reverted previous commit and added define to get the same types on all
platforms.

Signed-off-by: Rosen Penev <rosenp@gmail.com>