### PR TITLE
libj1939.h: fix typo

### DIFF
--- a/libj1939.h
+++ b/libj1939.h
@@ -10,7 +10,7 @@
  * as published by the Free Software Foundation
  */
 
-/* needed on some 644 bit platforms to get consistent 64-bit types */
+/* needed on some 64 bit platforms to get consistent 64-bit types */
 #define __SANE_USERSPACE_TYPES__
 
 #include <sys/socket.h>


### PR DESCRIPTION
Fixes: e370ad5256f4 ("testj1939: fix 64-bit types for some platforms")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>