### PR TITLE
isotp: support Linux 5.18 features

### DIFF
--- a/cangw.c
+++ b/cangw.c
@@ -774,7 +774,7 @@ int main(int argc, char **argv)
 			break;
 
 		case 'u':
-			uid = strtoul(optarg, (char **)NULL, 16);
+			uid = strtoul(optarg, NULL, 16);
 			break;
 
 		case 'l':

--- a/cansniffer.c
+++ b/cansniffer.c
@@ -931,7 +931,7 @@ int readsettings(char* name)
 			done = true;
 			continue;
 		}
-		unsigned long id = strtoul(&buf[1], (char **)NULL, 16);
+		unsigned long id = strtoul(&buf[1], NULL, 16);
 
 		sniftab[idx].current.can_id = id;
 
@@ -942,7 +942,7 @@ int readsettings(char* name)
 
 		for (j = max_dlen - 1; j >= 0 ; j--) {
 			sniftab[idx].notch.data[j] =
-				(__u8) strtoul(&buf[2*j+12], (char **)NULL, 16) & 0xFF;
+				(__u8) strtoul(&buf[2*j+12], NULL, 16) & 0xFF;
 			buf[2*j+12] = 0; /* cut off each time */
 		}
 

--- a/include/linux/can/isotp.h
+++ b/include/linux/can/isotp.h
@@ -137,19 +137,15 @@ struct can_isotp_ll_options {
 #define CAN_ISOTP_WAIT_TX_DONE	0x400	/* wait for tx completion */
 #define CAN_ISOTP_SF_BROADCAST	0x800	/* 1-to-N functional addressing */
 
-/* default values */
+/* protocol machine default values */
 
 #define CAN_ISOTP_DEFAULT_FLAGS		0
 #define CAN_ISOTP_DEFAULT_EXT_ADDRESS	0x00
 #define CAN_ISOTP_DEFAULT_PAD_CONTENT	0xCC /* prevent bit-stuffing */
-#define CAN_ISOTP_DEFAULT_FRAME_TXTIME	0
+#define CAN_ISOTP_DEFAULT_FRAME_TXTIME	50000 /* 50 micro seconds */
 #define CAN_ISOTP_DEFAULT_RECV_BS	0
 #define CAN_ISOTP_DEFAULT_RECV_STMIN	0x00
 #define CAN_ISOTP_DEFAULT_RECV_WFTMAX	0
-
-#define CAN_ISOTP_DEFAULT_LL_MTU	CAN_MTU
-#define CAN_ISOTP_DEFAULT_LL_TX_DL	CAN_MAX_DLEN
-#define CAN_ISOTP_DEFAULT_LL_TX_FLAGS	0
 
 /*
  * Remark on CAN_ISOTP_DEFAULT_RECV_* values:
@@ -161,5 +157,25 @@ struct can_isotp_ll_options {
  * For that reason the STmin value is intentionally _not_ checked for
  * consistency and copied directly into the flow control (FC) frame.
  */
+
+/* link layer default values => make use of Classical CAN frames */
+
+#define CAN_ISOTP_DEFAULT_LL_MTU	CAN_MTU
+#define CAN_ISOTP_DEFAULT_LL_TX_DL	CAN_MAX_DLEN
+#define CAN_ISOTP_DEFAULT_LL_TX_FLAGS	0
+
+/*
+ * The CAN_ISOTP_DEFAULT_FRAME_TXTIME has become a non-zero value as
+ * it only makes sense for isotp implementation tests to run without
+ * a N_As value. As user space applications usually do not set the
+ * frame_txtime element of struct can_isotp_options the new in-kernel
+ * default is very likely overwritten with zero when the sockopt()
+ * CAN_ISOTP_OPTS is invoked.
+ * To make sure that a N_As value of zero is only set intentional the
+ * value '0' is now interpreted as 'do not change the current value'.
+ * When a frame_txtime of zero is required for testing purposes this
+ * CAN_ISOTP_FRAME_TXTIME_ZERO u32 value has to be set in frame_txtime.
+ */
+#define CAN_ISOTP_FRAME_TXTIME_ZERO	0xFFFFFFFF
 
 #endif /* !_UAPI_CAN_ISOTP_H */

--- a/isotpdump.c
+++ b/isotpdump.c
@@ -225,13 +225,13 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "s:d:ax:X:ct:u?")) != -1) {
 		switch (opt) {
 		case 's':
-			src = strtoul(optarg, (char **)NULL, 16);
+			src = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				src |= CAN_EFF_FLAG;
 			break;
 
 		case 'd':
-			dst = strtoul(optarg, (char **)NULL, 16);
+			dst = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				dst |= CAN_EFF_FLAG;
 			break;
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 			if (!strncmp(optarg, "any", 3))
 				extany = 1;
 			else
-				extaddr = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+				extaddr = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'X':
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
 			if (!strncmp(optarg, "any", 3))
 				rx_extany = 1;
 			else
-				rx_extaddr = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+				rx_extaddr = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 't':

--- a/isotpperf.c
+++ b/isotpperf.c
@@ -121,25 +121,25 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "s:d:x:X:?")) != -1) {
 		switch (opt) {
 		case 's':
-			src = strtoul(optarg, (char **)NULL, 16);
+			src = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				src |= CAN_EFF_FLAG;
 			break;
 
 		case 'd':
-			dst = strtoul(optarg, (char **)NULL, 16);
+			dst = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				dst |= CAN_EFF_FLAG;
 			break;
 
 		case 'x':
 			ext = 1;
-			extaddr = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			extaddr = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'X':
 			rx_ext = 1;
-			rx_extaddr = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			rx_extaddr = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case '?':

--- a/isotprecv.c
+++ b/isotprecv.c
@@ -99,13 +99,13 @@ int main(int argc, char **argv)
     while ((opt = getopt(argc, argv, "s:d:x:p:P:b:m:w:f:lL:?")) != -1) {
 	    switch (opt) {
 	    case 's':
-		    addr.can_addr.tp.tx_id = strtoul(optarg, (char **)NULL, 16);
+		    addr.can_addr.tp.tx_id = strtoul(optarg, NULL, 16);
 		    if (strlen(optarg) > 7)
 			    addr.can_addr.tp.tx_id |= CAN_EFF_FLAG;
 		    break;
 
 	    case 'd':
-		    addr.can_addr.tp.rx_id = strtoul(optarg, (char **)NULL, 16);
+		    addr.can_addr.tp.rx_id = strtoul(optarg, NULL, 16);
 		    if (strlen(optarg) > 7)
 			    addr.can_addr.tp.rx_id |= CAN_EFF_FLAG;
 		    break;
@@ -163,20 +163,20 @@ int main(int argc, char **argv)
 		    break;
 
 	    case 'b':
-		    fcopts.bs = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+		    fcopts.bs = strtoul(optarg, NULL, 16) & 0xFF;
 		    break;
 
 	    case 'm':
-		    fcopts.stmin = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+		    fcopts.stmin = strtoul(optarg, NULL, 16) & 0xFF;
 		    break;
 
 	    case 'w':
-		    fcopts.wftmax = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+		    fcopts.wftmax = strtoul(optarg, NULL, 16) & 0xFF;
 		    break;
 
 	    case 'f':
 		    opts.flags |= CAN_ISOTP_FORCE_RXSTMIN;
-		    force_rx_stmin = strtoul(optarg, (char **)NULL, 10);
+		    force_rx_stmin = strtoul(optarg, NULL, 10);
 		    break;
 
 	    case 'l':

--- a/isotprecv.c
+++ b/isotprecv.c
@@ -57,7 +57,7 @@
 #include <linux/can/isotp.h>
 
 #define NO_CAN_ID 0xFFFFFFFFU
-#define BUFSIZE 5000 /* size > 4095 to check socket API internal checks */
+#define BUFSIZE 67000 /* size > 66000 to check socket API internal checks */
 
 void print_usage(char *prg)
 {

--- a/isotpsend.c
+++ b/isotpsend.c
@@ -104,13 +104,13 @@ int main(int argc, char **argv)
     while ((opt = getopt(argc, argv, "s:d:x:p:P:t:f:D:l:g:bSL:?")) != -1) {
 	    switch (opt) {
 	    case 's':
-		    addr.can_addr.tp.tx_id = strtoul(optarg, (char **)NULL, 16);
+		    addr.can_addr.tp.tx_id = strtoul(optarg, NULL, 16);
 		    if (strlen(optarg) > 7)
 			    addr.can_addr.tp.tx_id |= CAN_EFF_FLAG;
 		    break;
 
 	    case 'd':
-		    addr.can_addr.tp.rx_id = strtoul(optarg, (char **)NULL, 16);
+		    addr.can_addr.tp.rx_id = strtoul(optarg, NULL, 16);
 		    if (strlen(optarg) > 7)
 			    addr.can_addr.tp.rx_id |= CAN_EFF_FLAG;
 		    break;
@@ -171,16 +171,16 @@ int main(int argc, char **argv)
 		    if (!strncmp(optarg, ZERO_STRING, strlen(ZERO_STRING)))
 			    opts.frame_txtime = CAN_ISOTP_FRAME_TXTIME_ZERO;
 		    else
-			    opts.frame_txtime = strtoul(optarg, (char **)NULL, 10);
+			    opts.frame_txtime = strtoul(optarg, NULL, 10);
 		    break;
 
 	    case 'f':
 		    opts.flags |= CAN_ISOTP_FORCE_TXSTMIN;
-		    force_tx_stmin = strtoul(optarg, (char **)NULL, 10);
+		    force_tx_stmin = strtoul(optarg, NULL, 10);
 		    break;
 
 	    case 'D':
-		    datalen = strtoul(optarg, (char **)NULL, 10);
+		    datalen = strtoul(optarg, NULL, 10);
 		    if (!datalen || datalen >= BUFSIZE) {
 			    print_usage(basename(argv[0]));
 			    exit(0);

--- a/isotpsend.c
+++ b/isotpsend.c
@@ -57,7 +57,8 @@
 #include <linux/can/isotp.h>
 
 #define NO_CAN_ID 0xFFFFFFFFU
-#define BUFSIZE 5000 /* size > 4095 to check socket API internal checks */
+#define BUFSIZE 67000 /* size > 66000 kernel buf to test socket API internal checks */
+#define ZERO_STRING "ZERO"
 
 void print_usage(char *prg)
 {
@@ -68,7 +69,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -x <addr>[:<rxaddr>]  (extended addressing / opt. separate rxaddr)\n");
 	fprintf(stderr, "         -p [tx]:[rx]  (set and enable tx/rx padding bytes)\n");
 	fprintf(stderr, "         -P <mode>     (check rx padding for (l)ength (c)ontent (a)ll)\n");
-	fprintf(stderr, "         -t <time ns>  (frame transmit time (N_As) in nanosecs)\n");
+	fprintf(stderr, "         -t <time ns>  (frame transmit time (N_As) in nanosecs) (*)\n");
 	fprintf(stderr, "         -f <time ns>  (ignore FC and force local tx stmin value in nanosecs)\n");
 	fprintf(stderr, "         -D <len>      (send a fixed PDU with len bytes - no STDIN data)\n");
 	fprintf(stderr, "         -l <num>      (send num PDUs - use 'i' for infinite loop)\n");
@@ -78,6 +79,7 @@ void print_usage(char *prg)
 	fprintf(stderr, "         -L <mtu>:<tx_dl>:<tx_flags>  (link layer options for CAN FD)\n");
 	fprintf(stderr, "\nCAN IDs and addresses are given and expected in hexadecimal values.\n");
 	fprintf(stderr, "The pdu data is expected on STDIN in space separated ASCII hex values.\n");
+	fprintf(stderr, "(*) = Use '-t %s' to set N_As to zero for Linux version 5.18+\n", ZERO_STRING);
 	fprintf(stderr, "\n");
 }
 
@@ -166,7 +168,10 @@ int main(int argc, char **argv)
 		    break;
 
 	    case 't':
-		    opts.frame_txtime = strtoul(optarg, (char **)NULL, 10);
+		    if (!strncmp(optarg, ZERO_STRING, strlen(ZERO_STRING)))
+			    opts.frame_txtime = CAN_ISOTP_FRAME_TXTIME_ZERO;
+		    else
+			    opts.frame_txtime = strtoul(optarg, (char **)NULL, 10);
 		    break;
 
 	    case 'f':

--- a/isotpserver.c
+++ b/isotpserver.c
@@ -166,17 +166,17 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "l:s:d:x:p:P:b:m:w:t:L:v?")) != -1) {
 		switch (opt) {
 		case 'l':
-			local_port = strtoul(optarg, (char **)NULL, 10);
+			local_port = strtoul(optarg, NULL, 10);
 			break;
 
 		case 's':
-			caddr.can_addr.tp.tx_id = strtoul(optarg, (char **)NULL, 16);
+			caddr.can_addr.tp.tx_id = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				caddr.can_addr.tp.tx_id |= CAN_EFF_FLAG;
 			break;
 
 		case 'd':
-			caddr.can_addr.tp.rx_id = strtoul(optarg, (char **)NULL, 16);
+			caddr.can_addr.tp.rx_id = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				caddr.can_addr.tp.rx_id |= CAN_EFF_FLAG;
 			break;
@@ -234,19 +234,19 @@ int main(int argc, char **argv)
 			break;
 
 		case 'b':
-			fcopts.bs = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.bs = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'm':
-			fcopts.stmin = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.stmin = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'w':
-			fcopts.wftmax = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.wftmax = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 't':
-			opts.frame_txtime = strtoul(optarg, (char **)NULL, 10);
+			opts.frame_txtime = strtoul(optarg, NULL, 10);
 			break;
 
 		case 'L':

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -200,25 +200,25 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "s:d:x:X:h:ct:f:L:?")) != -1) {
 		switch (opt) {
 		case 's':
-			src = strtoul(optarg, (char **)NULL, 16);
+			src = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				src |= CAN_EFF_FLAG;
 			break;
 
 		case 'd':
-			dst = strtoul(optarg, (char **)NULL, 16);
+			dst = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				dst |= CAN_EFF_FLAG;
 			break;
 
 		case 'x':
 			opts.flags |= CAN_ISOTP_EXTEND_ADDR;
-			opts.ext_address = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			opts.ext_address = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'X':
 			opts.flags |= CAN_ISOTP_RX_EXT_ADDR;
-			opts.rx_ext_address = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			opts.rx_ext_address = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'f':

--- a/isotptun.c
+++ b/isotptun.c
@@ -154,13 +154,13 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "s:d:n:x:p:P:t:b:m:whL:vD?")) != -1) {
 		switch (opt) {
 		case 's':
-			addr.can_addr.tp.tx_id = strtoul(optarg, (char **)NULL, 16);
+			addr.can_addr.tp.tx_id = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				addr.can_addr.tp.tx_id |= CAN_EFF_FLAG;
 			break;
 
 		case 'd':
-			addr.can_addr.tp.rx_id = strtoul(optarg, (char **)NULL, 16);
+			addr.can_addr.tp.rx_id = strtoul(optarg, NULL, 16);
 			if (strlen(optarg) > 7)
 				addr.can_addr.tp.rx_id |= CAN_EFF_FLAG;
 			break;
@@ -228,19 +228,19 @@ int main(int argc, char **argv)
 			break;
 
 		case 't':
-			opts.frame_txtime = strtoul(optarg, (char **)NULL, 10);
+			opts.frame_txtime = strtoul(optarg, NULL, 10);
 			break;
 
 		case 'b':
-			fcopts.bs = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.bs = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'm':
-			fcopts.stmin = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.stmin = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'w':
-			fcopts.wftmax = strtoul(optarg, (char **)NULL, 16) & 0xFF;
+			fcopts.wftmax = strtoul(optarg, NULL, 16) & 0xFF;
 			break;
 
 		case 'h':


### PR DESCRIPTION
- update isotp.h include file
- update maximum PDU (buffer) size to 64kByte buffer
- support setting of N_As (frame_txtime) to zero

Signed-off-by: Oliver Hartkopp <socketcan@hartkopp.net>