### PR TITLE
Android.mk: fix compilation of can-calc-bit-timing

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -181,7 +181,7 @@ include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
-LOCAL_SRC_FILES := can-calc-bit-timing.c
+LOCAL_SRC_FILES := calc-bit-timing/can-calc-bit-timing.c
 LOCAL_MODULE := can-calc-bit-timing
 LOCAL_MODULE_TAGS := optional
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ set(PROGRAMS_J1939
 set(PROGRAMS
     ${PROGRAMS_CANLIB}
     bcmserver
-    can-calc-bit-timing
     canfdtest
     cangw
     cansniffer


### PR DESCRIPTION
Fixes: 9c38c16437e9 ("can-calc-bit-timing: move into subdir")
Reported-by: Tompee Balauag <tompee26@gmail.com>
Link: https://github.com/linux-can/can-utils/issues/373
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>