### PR TITLE
lib: fix seperator in snprintf_error_data

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -582,6 +582,7 @@ static int snprintf_error_data(char *buf, size_t len, uint8_t err,
 				return n;
 			}
 			n += tmp_n;
+			count++;
 		}
 	}
 


### PR DESCRIPTION
When multiple error flags are set, snprintf_error_data created a comma
seperated textual presentation of it. Commit ef853f555379 ("added return value
check of snprintf to prevent possible buffer overflows detected by CodeQL")
removed the increment of count, so the delimiter is no longer added. Fix this
by incrementing count again.

Fixes: ef853f555379 ("added return value check of snprintf to prevent possible buffer overflows detected by CodeQL")
Signed-off-by: Jeroen Hofstee <jhofstee@victronenergy.com>