### PR TITLE
Revert "cangen: use if_nametoindex() to avoid overflows"

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -608,11 +608,13 @@ int main(int argc, char **argv)
 	}
 
 	addr.can_family = AF_CAN;
-	addr.can_ifindex = if_nametoindex(argv[optind]);
-	if (!addr.can_ifindex) {
-		perror("if_nametoindex");
+
+	strcpy(ifr.ifr_name, argv[optind]);
+	if (ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
+		perror("SIOCGIFINDEX");
 		return 1;
 	}
+	addr.can_ifindex = ifr.ifr_ifindex;
 
 	/*
 	 * disable default receive filter on this RAW socket


### PR DESCRIPTION
This reverts commit 1f96d674c0cb7b60ee315981f12a7feb94829697.

Link: https://github.com/linux-can/can-utils/pull/396
Link: https://github.com/linux-can/can-utils/commit/1f96d674c0cb7b60ee315981f12a7feb94829697#commitcomment-97455025