### PR TITLE
cangen: print_usage(): add missing newlines

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -168,10 +168,10 @@ static void print_usage(char *prg)
 	fprintf(stderr, "Usage: %s [options] <CAN interface>\n", prg);
 	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "         -g <ms>       (gap in milli seconds - default: %d ms)\n", DEFAULT_GAP);
-	fprintf(stderr, "         -a            (use absolute time for gap)");
-	fprintf(stderr, "         -t            (use SO_TXTIME)");
-	fprintf(stderr, "         --start <ns>  (start time (UTC nanoseconds))");
-	fprintf(stderr, "         --mark <id>   (set SO_MARK to <id>, default %u)", DEFAULT_SO_MARK_VAL);
+	fprintf(stderr, "         -a            (use absolute time for gap)\n");
+	fprintf(stderr, "         -t            (use SO_TXTIME)\n");
+	fprintf(stderr, "         --start <ns>  (start time (UTC nanoseconds))\n");
+	fprintf(stderr, "         --mark <id>   (set SO_MARK to <id>, default %u)\n", DEFAULT_SO_MARK_VAL);
 	fprintf(stderr, "         -e            (generate extended frame mode (EFF) CAN frames)\n");
 	fprintf(stderr, "         -f            (generate CAN FD CAN frames)\n");
 	fprintf(stderr, "         -b            (generate CAN FD CAN frames with bitrate switch (BRS))\n");


### PR DESCRIPTION
Fixes: f55ea38d146a ("cangen: add option for absolute timeouts")
Fixes: c6f2cf7c2f27 ("cangen: add support for SO_TXTIME")