### PR TITLE
Exit status when signaled

### DIFF
--- a/canbusload.c
+++ b/canbusload.c
@@ -82,6 +82,8 @@ static struct {
 	unsigned int recv_bits_dbitrate;
 } stat[MAXSOCK+1];
 
+static volatile int running = 1;
+static volatile sig_atomic_t signal_num;
 static int  max_devname_len; /* to prevent frazzled device name output */ 
 static int  max_bitrate_len;
 static int  currmax;
@@ -124,7 +126,8 @@ void print_usage(char *prg)
 
 void sigterm(int signo)
 {
-	exit(0);
+	running = 0;
+	signal_num = signo;
 }
 
 void printstats(int signo)
@@ -382,7 +385,7 @@ int main(int argc, char **argv)
 	if (redraw)
 		printf("%s", CLR_SCREEN);
 
-	while (1) {
+	while (running) {
 
 		FD_ZERO(&rdfs);
 		for (i=0; i<currmax; i++)
@@ -424,6 +427,9 @@ int main(int argc, char **argv)
 
 	for (i=0; i<currmax; i++)
 		close(s[i]);
+
+	if (signal_num)
+		return 128 + signal_num;
 
 	return 0;
 }

--- a/candump.c
+++ b/candump.c
@@ -118,6 +118,7 @@ static const char extra_m_info[4][4] = { "- -", "B -", "- E", "B E" };
 extern int optind, opterr, optopt;
 
 static volatile int running = 1;
+static volatile sig_atomic_t signal_num;
 
 static void print_usage(void)
 {
@@ -169,6 +170,7 @@ static void print_usage(void)
 static void sigterm(int signo)
 {
 	running = 0;
+	signal_num = signo;
 }
 
 static int idx2dindex(int ifidx, int socket)
@@ -860,6 +862,9 @@ int main(int argc, char **argv)
 
 	if (log)
 		fclose(logfile);
+
+	if (signal_num)
+		return 128 + signal_num;
 
 	return 0;
 }

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -584,10 +584,8 @@ int main(int argc, char *argv[])
 
 	close(sockfd);
 
-	if (exit_sig) {
-		signal(exit_sig, SIG_DFL);
-		kill(getpid(), exit_sig);
-	}
+	if (exit_sig)
+		return 128 + exit_sig;
 
 	return err;
 }

--- a/cangen.c
+++ b/cangen.c
@@ -91,6 +91,7 @@
 extern int optind, opterr, optopt;
 
 static volatile int running = 1;
+static volatile sig_atomic_t signal_num;
 static unsigned long long enobufs_count;
 static bool ignore_enobufs;
 static bool use_so_txtime;
@@ -220,6 +221,7 @@ static void print_usage(char *prg)
 static void sigterm(int signo)
 {
 	running = 0;
+	signal_num = signo;
 }
 
 static int setsockopt_txtime(int fd)
@@ -886,6 +888,9 @@ int main(int argc, char **argv)
 		       enobufs_count);
 
 	close(s);
+
+	if (signal_num)
+		return 128 + signal_num;
 
 	return 0;
 }

--- a/canlogserver.c
+++ b/canlogserver.c
@@ -84,6 +84,7 @@ static int  max_devname_len;
 extern int optind, opterr, optopt;
 
 static volatile int running = 1;
+static volatile sig_atomic_t signal_num;
 
 void print_usage(char *prg)
 {
@@ -164,7 +165,8 @@ void childdied(int i)
  */
 void shutdown_gra(int i)
 {
-	exit(0);
+	running = 0;
+	signal_num = i;
 }
 
 
@@ -433,5 +435,9 @@ int main(int argc, char **argv)
 		close(s[i]);
 
 	close(accsocket);
+
+	if (signal_num)
+		return 128 + signal_num;
+
 	return 0;
 }

--- a/cansequence.c
+++ b/cansequence.c
@@ -33,6 +33,7 @@ extern int optind, opterr, optopt;
 
 static int s = -1;
 static bool running = true;
+static volatile sig_atomic_t signal_num;
 static bool infinite = true;
 static unsigned int drop_until_quit;
 static unsigned int drop_count;
@@ -73,6 +74,7 @@ static void print_usage(char *prg)
 static void sig_handler(int signo)
 {
 	running = false;
+	signal_num = signo;
 }
 
 
@@ -366,6 +368,9 @@ int main(int argc, char **argv)
 		do_receive();
 	else
 		do_send();
+
+	if (signal_num)
+		return 128 + signal_num;
 
 	exit(EXIT_SUCCESS);
 }

--- a/cansniffer.c
+++ b/cansniffer.c
@@ -124,6 +124,7 @@ extern int optind, opterr, optopt;
 
 static int idx;
 static int running = 1;
+static volatile sig_atomic_t signal_num;
 static int clearscreen = 1;
 static int print_eff;
 static int print_ascii = 1;
@@ -243,6 +244,7 @@ void print_usage(char *prg)
 void sigterm(int signo)
 {
 	running = 0;
+	signal_num = signo;
 }
 
 int main(int argc, char **argv)
@@ -428,6 +430,10 @@ int main(int argc, char **argv)
 	printf("%s", CSR_SHOW); /* show cursor */
 
 	close(s);
+
+	if (signal_num)
+		return 128 + signal_num;
+
 	return ret;
 }
 

--- a/isotptun.c
+++ b/isotptun.c
@@ -79,6 +79,7 @@
 #define BUF_LEN (MAX_PDU_LENGTH + 1)
 
 static volatile int running = 1;
+static volatile sig_atomic_t signal_num;
 
 static void fake_syslog(int priority, const char *format, ...)
 {
@@ -130,6 +131,7 @@ void print_usage(char *prg)
 void sigterm(int signo)
 {
 	running = 0;
+	signal_num = signo;
 }
 
 int main(int argc, char **argv)
@@ -403,5 +405,9 @@ int main(int argc, char **argv)
 
 	close(s);
 	close(t);
+
+	if (signal_num)
+		return 128 + signal_num;
+
 	return EXIT_SUCCESS;
 }

--- a/slcand.c
+++ b/slcand.c
@@ -93,7 +93,7 @@ void print_usage(char *prg)
 }
 
 static int slcand_running;
-static int exit_code;
+static volatile sig_atomic_t exit_code;
 static char ttypath[TTYPATH_LENGTH];
 
 static void child_handler(int signum)
@@ -104,16 +104,12 @@ static void child_handler(int signum)
 		/* exit parent */
 		exit(EXIT_SUCCESS);
 		break;
+	case SIGINT:
+	case SIGTERM:
 	case SIGALRM:
 	case SIGCHLD:
 		syslogger(LOG_NOTICE, "received signal %i on %s", signum, ttypath);
-		exit_code = EXIT_FAILURE;
-		slcand_running = 0;
-		break;
-	case SIGINT:
-	case SIGTERM:
-		syslogger(LOG_NOTICE, "received signal %i on %s", signum, ttypath);
-		exit_code = EXIT_SUCCESS;
+		exit_code = 128 + signum;
 		slcand_running = 0;
 		break;
 	}


### PR DESCRIPTION
Sorry to be late.  Here is the PR to fix the exit code when signaled.

I've left each fie a separate commit for your convinience.  I'm sure it's easier to merge than split.

I'd merge `candump`, `cangen`, `cansequence`, `cansniffer`, and `isotptun` as one commit because the fix for these is simplely introducing `signal_num` and check and return.

j1939acd is similar to the above but using a struct.

`canbusload` and `canlogserver` were calling non-safe command, exit(3), in the signal handler.  Merging these two is a good idea, I'd say.

`canfdtest` was raising the signal it received, not by `raise(3)` but `kill(3)`, which was declined by @hartkopp.  Thus, this PR has a commit to fix it to `return 128 + signum`.

`slcand` was different.  It explicity returning `EXIT_SUCCESS` when either SIGINT or SIGTERM is received.  I've changed it to return 128 + signum but might be breaking the orignal author's intention.  Happy to drop it if I'm misreading it.

Hope you like it.

This closes #408 