### PR TITLE
canlogserver: Fix termination after signal

### DIFF
--- a/canlogserver.c
+++ b/canlogserver.c
@@ -306,6 +306,15 @@ int main(int argc, char **argv)
 			perror("accept");
 			exit(1);
 		}
+		else if ((errno == EINTR) && !running) {
+			close(socki);
+			if (signal_num) {
+				return 128 + signal_num;
+			}
+			else {
+				return 1;
+			}
+		}
 	}
 
 	for (i=0; i<currmax; i++) {


### PR DESCRIPTION
With f45de1b782c083, we've removed unsafe function exit(3) from the signal handler.  But that made canlogserver's accept(3)ing process not exit; It unconditionally keeps running with EINTR.

Check the variable "running" when signaled and exit with an appropriate error code.