### PR TITLE
canbusload: Enhance error message for missing bitrate

### DIFF
--- a/canbusload.c
+++ b/canbusload.c
@@ -325,6 +325,7 @@ int main(int argc, char **argv)
 		nptr = strchr(ptr, '@');
 
 		if (!nptr) {
+			fprintf(stderr, "Specify CAN interfaces in the form <CAN interface>@<bitrate>, e.g. can0@500000\n");
 			print_usage(prg);
 			return 1;
 		}


### PR DESCRIPTION
When canbusload is executed without bit rate, it exits with an exit code of 1 and prints help, but without explaining why.  Users cannot know what was wrong.  When other errors occur, though, canbusload prints an error message along with the help.

Print an error message when bit rate is not given or "@" is not found.