### PR TITLE
cangen: parse_dataoptarg(): avoid loop initial declaration

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -417,9 +417,10 @@ static int parse_dataoptarg(char *dataoptarg, unsigned char *rand_position)
 {
 	int mode_format_selected = MODE_FIX;
 	int arglen = strlen(dataoptarg);
+	int i;
 
 	/* Mark nibbles with * as fuzzable */
-	for (int i = 0; i < CANFD_MAX_DLEN && i < arglen / 2; i++) {
+	for (i = 0; i < CANFD_MAX_DLEN && i < arglen / 2; i++) {
 		if (optarg[2 * i] == CHAR_RANDOM) {
 			optarg[2 * i] = '0';
 			rand_position[i] += NIBBLE_H;


### PR DESCRIPTION
| cangen.c: In function ‘parse_dataoptarg’:
| cangen.c:422:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
|   for (int i = 0; i < CANFD_MAX_DLEN && i < arglen / 2; i++) {
|   ^
| cangen.c:422:2: note: use option -std=c99 or -std=gnu99 to compile your code
| cangen.c: In function ‘main’:
| cangen.c:796:4: error: ‘for’ loop initial declarations are only allowed in C99 mode
|     for (int i = 0; i < frame.len; i++) {
|     ^

Reported-by: https://github.com/yannS2016
Link: https://github.com/linux-can/can-utils/issues/428
Fixes: e409aa4c8c31 ("cangen: new generation mode - partially randomized payload (-D)")