### PR TITLE
cangen: main(): avoid loop initial declaration

### DIFF
--- a/cangen.c
+++ b/cangen.c
@@ -792,9 +792,11 @@ int main(int argc, char **argv)
 		}
 
 		if (data_mode == MODE_RANDOM_FIX) {
+			int i;
+			
 			memcpy(frame.data, fixdata, CANFD_MAX_DLEN);
 
-			for (int i = 0; i < frame.len; i++) {
+			for (i = 0; i < frame.len; i++) {
 				if (rand_position[i] == (NIBBLE_H | NIBBLE_L)) {
 					frame.data[i] = random();
 				} else if (rand_position[i] == NIBBLE_H) {


### PR DESCRIPTION
| cangen.c: In function ‘parse_dataoptarg’:
| cangen.c:422:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
|   for (int i = 0; i < CANFD_MAX_DLEN && i < arglen / 2; i++) {
|   ^
| cangen.c:422:2: note: use option -std=c99 or -std=gnu99 to compile your code
| cangen.c: In function ‘main’:
| cangen.c:796:4: error: ‘for’ loop initial declarations are only allowed in C99 mode
|     for (int i = 0; i < frame.len; i++) {
|     ^

Reported-by: https://github.com/yannS2016
Link: https://github.com/linux-can/can-utils/issues/428
Fixes: e409aa4c8c31 ("cangen: new generation mode - partially randomized payload (-D)")