### PR TITLE
cansequence: remove --version option from help text

### DIFF
--- a/cansequence.c
+++ b/cansequence.c
@@ -67,8 +67,7 @@ static void print_usage(char *prg)
 		" -q, --quit <num>	quit if <num> wrong sequences are encountered\n"
 		" -r, --receive		work as receiver\n"
 		" -v, --verbose		be verbose (twice to be even more verbose\n"
-		" -h, --help		this help\n"
-		"     --version		print version information and exit\n",
+		" -h, --help		this help\n",
 		prg, CAN_ID_DEFAULT);
 }
 


### PR DESCRIPTION
It is not implemented and not supported by any of the can-utils, so remove it.