### PR TITLE
cansequence: error messages

### DIFF
--- a/cansequence.c
+++ b/cansequence.c
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
 	if (strcmp(ANYDEV, interface)) {
 		addr.can_ifindex = if_nametoindex(interface);
 		if (!addr.can_ifindex) {
-			perror("if_nametoindex");
+			perror("if_nametoindex()");
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/cansequence.c
+++ b/cansequence.c
@@ -125,7 +125,7 @@ static void do_receive()
 
 		nbytes = recvmsg(s, &msg, 0);
 		if (nbytes < 0) {
-			perror("read()");
+			perror("recvmsg()");
 			exit(EXIT_FAILURE);
 		}
 


### PR DESCRIPTION
Streamline error messages for failing syscalls.