### PR TITLE
can-calc-bit-timing: print_usage(): add --tq parameter to help text

### DIFF
--- a/calc-bit-timing/can-calc-bit-timing.c
+++ b/calc-bit-timing/can-calc-bit-timing.c
@@ -108,6 +108,7 @@ static void print_usage(char *cmd)
 	       "\n"
 	       "Or supply low level bit timing parameters to decode them:\n"
 	       "\n"
+	       "\t--tq           Time quantum in ns\n"
 	       "\t--prop-seg     Propagation segment in TQs\n"
 	       "\t--phase-seg1   Phase buffer segment 1 in TQs\n"
 	       "\t--phase-seg2   Phase buffer segment 2 in TQs\n"


### PR DESCRIPTION
In 913311fc15a2 ("can-calc-bit-timing: add support to decode user supplied bit timing parameters") support to decide user supplied bit timing parameters was added. However, it was forgotten to add --tq to the help text.

Add help text for the --tq paramter.

Reported-by: https://github.com/EnricoMontecaggi
Closes: https://github.com/linux-can/can-utils/issues/459
Fixes: 913311fc15a2 ("can-calc-bit-timing: add support to decode user supplied bit timing parameters")