### PR TITLE
timestamp formatting: always use 64-bit for timesstamp formatting.

### DIFF
--- a/candump.c
+++ b/candump.c
@@ -226,7 +226,7 @@ static inline void sprint_timestamp(const char timestamp, const struct timeval *
 {
 	switch (timestamp) {
 	case 'a': /* absolute with timestamp */
-		sprintf(ts_buffer, "(%010lu.%06lu) ", tv->tv_sec, tv->tv_usec);
+		sprintf(ts_buffer, "(%010llu.%06llu) ", (unsigned long long)tv->tv_sec, (unsigned long long)tv->tv_usec);
 		break;
 
 	case 'A': /* absolute with date */
@@ -236,7 +236,7 @@ static inline void sprint_timestamp(const char timestamp, const struct timeval *
 
 		tm = *localtime(&tv->tv_sec);
 		strftime(timestring, 24, "%Y-%m-%d %H:%M:%S", &tm);
-		sprintf(ts_buffer, "(%s.%06lu) ", timestring, tv->tv_usec);
+		sprintf(ts_buffer, "(%s.%06llu) ", timestring, (unsigned long long)tv->tv_usec);
 	}
 	break;
 
@@ -253,7 +253,7 @@ static inline void sprint_timestamp(const char timestamp, const struct timeval *
 			diff.tv_sec--, diff.tv_usec += 1000000;
 		if (diff.tv_sec < 0)
 			diff.tv_sec = diff.tv_usec = 0;
-		sprintf(ts_buffer, "(%03lu.%06lu) ", diff.tv_sec, diff.tv_usec);
+		sprintf(ts_buffer, "(%03llu.%06llu) ", (unsigned long long)diff.tv_sec, (unsigned long long)diff.tv_usec);
 
 		if (timestamp == 'd')
 			*last_tv = *tv; /* update for delta calculation */

--- a/canlogserver.c
+++ b/canlogserver.c
@@ -415,8 +415,8 @@ int main(int argc, char **argv)
 
 				idx = idx2dindex(addr.can_ifindex, s[i]);
 
-				sprintf(temp, "(%lu.%06lu) %*s ",
-					tv.tv_sec, tv.tv_usec, max_devname_len, devname[idx]);
+				sprintf(temp, "(%llu.%06llu) %*s ",
+					(unsigned long long)tv.tv_sec, (unsigned long long)tv.tv_usec, max_devname_len, devname[idx]);
 				sprint_canframe(temp+strlen(temp), &frame, 0, maxdlen); 
 				strcat(temp, "\n");
 

--- a/canplayer.c
+++ b/canplayer.c
@@ -259,6 +259,7 @@ int main(int argc, char **argv)
 	int txidx; /* sendto() interface index */
 	int eof, txmtu, i, j;
 	char *fret;
+	unsigned long long sec, usec;
 
 	while ((opt = getopt(argc, argv, "I:l:tin:g:s:xv?")) != -1) {
 		switch (opt) {
@@ -416,10 +417,12 @@ int main(int argc, char **argv)
 
 		eof = 0;
 
-		if (sscanf(buf, "(%lu.%lu) %s %s", &log_tv.tv_sec, &log_tv.tv_usec, device, ascframe) != 4) {
+		if (sscanf(buf, "(%llu.%llu) %s %s", &sec, &usec, device, ascframe) != 4) {
 			fprintf(stderr, "incorrect line format in logfile\n");
 			return 1;
 		}
+		log_tv.tv_sec = sec;
+		log_tv.tv_usec = usec;
 
 		/*
 		 * ensure the fractions of seconds are 6 decimal places long to catch
@@ -507,10 +510,12 @@ int main(int argc, char **argv)
 					break;
 				}
 
-				if (sscanf(buf, "(%lu.%lu) %s %s", &log_tv.tv_sec, &log_tv.tv_usec, device, ascframe) != 4) {
+				if (sscanf(buf, "(%llu.%llu) %s %s", &sec, &usec, device, ascframe) != 4) {
 					fprintf(stderr, "incorrect line format in logfile\n");
 					return 1;
 				}
+				log_tv.tv_sec = sec;
+				log_tv.tv_usec = usec;
 
 				/*
 				 * ensure the fractions of seconds are 6 decimal places long to catch

--- a/isotpdump.c
+++ b/isotpdump.c
@@ -361,7 +361,7 @@ int main(int argc, char **argv)
 
 			switch (timestamp) {
 			case 'a': /* absolute with timestamp */
-				printf("(%lu.%06lu) ", tv.tv_sec, tv.tv_usec);
+				printf("(%llu.%06llu) ", (unsigned long long)tv.tv_sec, (unsigned long long)tv.tv_usec);
 				break;
 
 			case 'A': /* absolute with date */
@@ -372,7 +372,7 @@ int main(int argc, char **argv)
 				tm = *localtime(&tv.tv_sec);
 				strftime(timestring, 24, "%Y-%m-%d %H:%M:%S",
 					 &tm);
-				printf("(%s.%06lu) ", timestring, tv.tv_usec);
+				printf("(%s.%06llu) ", timestring, (unsigned long long)tv.tv_usec);
 			} break;
 
 			case 'd': /* delta */
@@ -388,8 +388,8 @@ int main(int argc, char **argv)
 					diff.tv_sec--, diff.tv_usec += 1000000;
 				if (diff.tv_sec < 0)
 					diff.tv_sec = diff.tv_usec = 0;
-				printf("(%lu.%06lu) ", diff.tv_sec,
-				       diff.tv_usec);
+				printf("(%llu.%06llu) ", (unsigned long long)diff.tv_sec,
+				       (unsigned long long)diff.tv_usec);
 
 				if (timestamp == 'd')
 					last_tv =

--- a/isotpperf.c
+++ b/isotpperf.c
@@ -403,9 +403,9 @@ int main(int argc, char **argv)
 
 				/* check devisor to be not zero */
 				if (diff_tv.tv_sec * 1000 + diff_tv.tv_usec / 1000){
-					printf("%lu.%06lus ", diff_tv.tv_sec, diff_tv.tv_usec);
+					printf("%llu.%06llus ", (unsigned long long)diff_tv.tv_sec, (unsigned long long)diff_tv.tv_usec);
 					printf("=> %lu byte/s", (fflen * 1000) /
-					       (diff_tv.tv_sec * 1000 + diff_tv.tv_usec / 1000));
+					       (unsigned long)(diff_tv.tv_sec * 1000 + diff_tv.tv_usec / 1000));
 				} else
 					printf("(no time available)     ");
 

--- a/isotpsniffer.c
+++ b/isotpsniffer.c
@@ -101,7 +101,7 @@ void printbuf(unsigned char *buffer, int nbytes, int color, int timestamp,
 		switch (timestamp) {
 
 		case 'a': /* absolute with timestamp */
-			printf("(%lu.%06lu) ", tv->tv_sec, tv->tv_usec);
+			printf("(%llu.%06llu) ", (unsigned long long)tv->tv_sec, (unsigned long long)tv->tv_usec);
 			break;
 
 		case 'A': /* absolute with date */
@@ -111,7 +111,7 @@ void printbuf(unsigned char *buffer, int nbytes, int color, int timestamp,
 
 			tm = *localtime(&tv->tv_sec);
 			strftime(timestring, 24, "%Y-%m-%d %H:%M:%S", &tm);
-			printf("(%s.%06lu) ", timestring, tv->tv_usec);
+			printf("(%s.%06llu) ", timestring, (unsigned long long)tv->tv_usec);
 		}
 		break;
 
@@ -128,7 +128,7 @@ void printbuf(unsigned char *buffer, int nbytes, int color, int timestamp,
 				diff.tv_sec--, diff.tv_usec += 1000000;
 			if (diff.tv_sec < 0)
 				diff.tv_sec = diff.tv_usec = 0;
-			printf("(%lu.%06lu) ", diff.tv_sec, diff.tv_usec);
+			printf("(%llu.%06llu) ", (unsigned long long)diff.tv_sec, (unsigned long long)diff.tv_usec);
 
 			if (timestamp == 'd')
 				*last_tv = *tv; /* update for delta calculation */

--- a/j1939cat.c
+++ b/j1939cat.c
@@ -148,8 +148,8 @@ static void j1939cat_print_timestamp(struct j1939cat_priv *priv, const char *nam
 	if (!(cur->tv_sec | cur->tv_nsec))
 		return;
 
-	fprintf(stderr, "  %s: %lu s %lu us (seq=%03u, send=%07u)",
-			name, cur->tv_sec, cur->tv_nsec / 1000,
+	fprintf(stderr, "  %s: %llu s %llu us (seq=%03u, send=%07u)",
+			name, (unsigned long long)cur->tv_sec, (unsigned long long)cur->tv_nsec / 1000,
 			stats->tskey, stats->send);
 
 	fprintf(stderr, "\n");

--- a/j1939spy.c
+++ b/j1939spy.c
@@ -259,14 +259,14 @@ int main(int argc, char **argv)
 				goto abs_time;
 			} else if ('a' == s.time) {
 abs_time:
-				printf("(%lu.%04lu)", tdut.tv_sec, tdut.tv_usec / 100);
+				printf("(%llu.%04llu)", (unsigned long long)tdut.tv_sec, (unsigned long long)tdut.tv_usec / 100);
 			} else if ('A' == s.time) {
 				struct tm tm;
 				tm = *localtime(&tdut.tv_sec);
-				printf("(%04u%02u%02uT%02u%02u%02u.%04lu)",
+				printf("(%04u%02u%02uT%02u%02u%02u.%04llu)",
 					tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
 					tm.tm_hour, tm.tm_min, tm.tm_sec,
-					tdut.tv_usec/100);
+					(unsigned long long)tdut.tv_usec/100);
 			}
 		}
 		printf(" %s ", libj1939_addr2str(&src));

--- a/log2asc.c
+++ b/log2asc.c
@@ -191,6 +191,7 @@ int main(int argc, char **argv)
 	FILE *outfile = stdout;
 	static int maxdev, devno, i, crlf, fdfmt, nortrdlc, d4, opt, mtu;
 	int print_banner = 1;
+	unsigned long long sec, usec;
 
 	while ((opt = getopt(argc, argv, "I:O:4nfr?")) != -1) {
 		switch (opt) {
@@ -260,18 +261,20 @@ int main(int argc, char **argv)
 		if (buf[0] != '(')
 			continue;
 
-		if (sscanf(buf, "(%lu.%lu) %s %s %s", &tv.tv_sec, &tv.tv_usec,
+		if (sscanf(buf, "(%llu.%llu) %s %s %s", &sec, &usec,
 			   device, ascframe, extra_info) != 5) {
 
 			/* do not evaluate the extra info */
 			extra_info[0] = 0;
 
-			if (sscanf(buf, "(%lu.%lu) %s %s", &tv.tv_sec, &tv.tv_usec,
+			if (sscanf(buf, "(%llu.%llu) %s %s", &sec, &usec,
 				   device, ascframe) != 4) {
 				fprintf(stderr, "incorrect line format in logfile\n");
 				return 1;
 			}
 		}
+		tv.tv_sec = sec;
+		tv.tv_usec = usec;
 
 		if (print_banner) { /* print banner */
 			print_banner = 0;
@@ -307,9 +310,9 @@ int main(int argc, char **argv)
 				tv.tv_sec = tv.tv_usec = 0;
 
 			if (d4)
-				fprintf(outfile, "%4lu.%04lu ", tv.tv_sec, tv.tv_usec/100);
+				fprintf(outfile, "%4llu.%04llu ", (unsigned long long)tv.tv_sec, (unsigned long long)tv.tv_usec/100);
 			else
-				fprintf(outfile, "%4lu.%06lu ", tv.tv_sec, tv.tv_usec);
+				fprintf(outfile, "%4llu.%06llu ", (unsigned long long)tv.tv_sec, (unsigned long long)tv.tv_usec);
 
 			if ((mtu == CAN_MTU) && (fdfmt == 0))
 				can_asc(&cf, devno, nortrdlc, extra_info, outfile);

--- a/slcanpty.c
+++ b/slcanpty.c
@@ -363,8 +363,8 @@ int can2pty(int pty, int socket, int *tstamp)
 		if (ioctl(socket, SIOCGSTAMP, &tv) < 0)
 			perror("SIOCGSTAMP");
 
-		sprintf(&buf[ptr + 2*frame.can_dlc], "%04lX",
-			(tv.tv_sec%60)*1000 + tv.tv_usec/1000);
+		sprintf(&buf[ptr + 2*frame.can_dlc], "%04llX",
+			(unsigned long long)(tv.tv_sec%60)*1000 + tv.tv_usec/1000);
 	}
 
 	strcat(buf, "\r"); /* add terminating character */


### PR DESCRIPTION
Using C99 `unsigned long long` to format `struct timeval`'s `tv_sec` and `tv_usec`, fix incorrect print under some 32bit platform which using time64.

To fix issue #469. It may looks ugly, but straightforward.