### PR TITLE
update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,5 +113,6 @@ foreach(name ${PROGRAMS})
   install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach()
 
+install(TARGETS can-calc-bit-timing mcp251xfd-dump DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/make_uninstall.cmake")


### PR DESCRIPTION
I am maintaining the [AUR can-utils-git](https://aur.archlinux.org/packages/can-utils-git) package, I found that the packaging operation is missing the can-calc-bit-timing mcp251xfd-dump file, add here to modify, thanks.