### PR TITLE
canfdtest: fix filter for extended frames and some cleanups

### DIFF
--- a/canfdtest.c
+++ b/canfdtest.c
@@ -65,7 +65,7 @@ static void print_usage(char *prg)
 {
 	fprintf(stderr,
 		"%s - Full-duplex test program (DUT and host part).\n"
-		"Usage: %s [options] <can-interface>\n"
+		"Usage: %s [options] [<can-interface>]\n"
 		"\n"
 		"Options:\n"
 		"         -b       (enable CAN FD Bit Rate Switch)\n"
@@ -85,6 +85,8 @@ static void print_usage(char *prg)
 		"on <can-interface>, otherwise all messages received on the\n"
 		"<can-interface> are sent back incrementing the CAN id and\n"
 		"all data bytes. The program can be aborted with ^C.\n"
+		"\n"
+		"Using 'can0' as default CAN-interface.\n"
 		"\n"
 		"Examples:\n"
 		"\ton DUT:\n"
@@ -428,7 +430,7 @@ out_free_tx_frames:
 int main(int argc, char *argv[])
 {
 	struct sockaddr_can addr;
-	char *intf_name;
+	char *intf_name = "can0";
 	int family = PF_CAN, type = SOCK_RAW, proto = CAN_RAW;
 	int echo_gen = 0;
 	int opt, err;
@@ -519,9 +521,10 @@ int main(int argc, char *argv[])
 	can_id_ping = normalize_canid(can_id_ping);
 	can_id_pong = normalize_canid(can_id_pong);
 
-	if ((argc - optind) != 1)
+	if ((argc - optind) == 1)
+		intf_name = argv[optind];
+	else if ((argc - optind))
 		print_usage(basename(argv[0]));
-	intf_name = argv[optind];
 
 	printf("interface = %s, family = %d, type = %d, proto = %d\n",
 	       intf_name, family, type, proto);

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -314,7 +314,6 @@ static int can_echo_gen(void)
 {
 	struct canfd_frame *tx_frames;
 	bool *recv_tx;
-	struct canfd_frame rx_frame;
 	unsigned char counter = 0;
 	int send_pos = 0, recv_rx_pos = 0, recv_tx_pos = 0, unprocessed = 0, loops = 0;
 	int err = 0;
@@ -357,6 +356,8 @@ static int can_echo_gen(void)
 			else
 				millisleep(1);
 		} else {
+			struct canfd_frame rx_frame;
+
 			if (recv_frame(&rx_frame)) {
 				err = -1;
 				goto out_free;

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -346,8 +346,8 @@ static int can_echo_gen(void)
 			}
 
 			send_pos++;
-			if (send_pos == inflight_count)
-				send_pos = 0;
+			send_pos %= inflight_count;
+
 			unprocessed++;
 			if (verbose == 1)
 				echo_progress(counter);
@@ -373,8 +373,7 @@ static int can_echo_gen(void)
 				err = compare_frame(&tx_frames[recv_tx_pos], &rx_frame, 0);
 				recv_tx[recv_tx_pos] = true;
 				recv_tx_pos++;
-				if (recv_tx_pos == inflight_count)
-					recv_tx_pos = 0;
+				recv_tx_pos %= inflight_count;
 				continue;
 			}
 
@@ -386,8 +385,7 @@ static int can_echo_gen(void)
 			/* compare with expected */
 			err = compare_frame(&tx_frames[recv_rx_pos], &rx_frame, 1);
 			recv_rx_pos++;
-			if (recv_rx_pos == inflight_count)
-				recv_rx_pos = 0;
+			recv_rx_pos %= inflight_count;
 
 			loops++;
 			if (test_loops && loops >= test_loops)

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -332,13 +332,15 @@ static int can_echo_gen(void)
 	while (running) {
 		if (unprocessed < inflight_count) {
 			/* still send messages */
-			tx_frames[send_pos].len = msg_len;
-			tx_frames[send_pos].can_id = can_id_ping;
+			struct canfd_frame *tx_frame = &tx_frames[send_pos];
+
+			tx_frame->len = msg_len;
+			tx_frame->can_id = can_id_ping;
 			recv_tx[send_pos] = false;
 
 			for (i = 0; i < msg_len; i++)
-				tx_frames[send_pos].data[i] = counter + i;
-			if (send_frame(&tx_frames[send_pos])) {
+				tx_frame->data[i] = counter + i;
+			if (send_frame(tx_frame)) {
 				err = -1;
 				goto out_free;
 			}

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -121,6 +121,18 @@ static void print_compare(canid_t exp_id, const uint8_t *exp_data, uint8_t exp_d
 	print_frame(rec_id, rec_data, rec_dlc, 0);
 }
 
+static canid_t normalize_canid(canid_t id)
+{
+	if (is_extended_frame_format) {
+		id &= CAN_EFF_MASK;
+		id |= CAN_EFF_FLAG;
+	} else {
+		id &= CAN_SFF_MASK;
+	}
+
+	return id;
+}
+
 static int compare_frame(const struct canfd_frame *exp, const struct canfd_frame *rec, int inc)
 {
 	int i, err = 0;
@@ -277,7 +289,7 @@ static void inc_frame(struct canfd_frame *frame)
 	if (has_pong_id)
 		frame->can_id = can_id_pong;
 	else
-		frame->can_id++;
+		frame->can_id = normalize_canid(frame->can_id + 1);
 
 	for (i = 0; i < frame->len; i++)
 		frame->data[i]++;
@@ -504,15 +516,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (is_extended_frame_format) {
-		can_id_ping &= CAN_EFF_MASK;
-		can_id_ping |= CAN_EFF_FLAG;
-		can_id_pong &= CAN_EFF_MASK;
-		can_id_pong |= CAN_EFF_FLAG;
-	} else {
-		can_id_ping &= CAN_SFF_MASK;
-		can_id_pong &= CAN_SFF_MASK;
-	}
+	can_id_ping = normalize_canid(can_id_ping);
+	can_id_pong = normalize_canid(can_id_pong);
 
 	if ((argc - optind) != 1)
 		print_usage(basename(argv[0]));

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -54,11 +54,11 @@ static int exit_sig;
 static int inflight_count = CAN_MSG_COUNT;
 static canid_t can_id_ping = CAN_MSG_ID_PING;
 static canid_t can_id_pong = CAN_MSG_ID_PONG;
-static int has_pong_id = 0;
-static int is_can_fd = 0;
-static int bit_rate_switch = 0;
+static int has_pong_id;
+static int is_can_fd;
+static int bit_rate_switch;
 static int msg_len = CAN_MSG_LEN;
-static int is_extended_frame_format = 0;
+static int is_extended_frame_format;
 
 static void print_usage(char *prg)
 {

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -553,11 +553,11 @@ int main(int argc, char *argv[])
 		const struct can_filter filters[] = {
 			{
 				.can_id = can_id_ping,
-				.can_mask = CAN_EFF_FLAG | CAN_RTR_FLAG | CAN_SFF_MASK,
+				.can_mask = CAN_EFF_FLAG | CAN_RTR_FLAG | CAN_EFF_MASK,
 			},
 			{
 				.can_id = can_id_pong,
-				.can_mask = CAN_EFF_FLAG | CAN_RTR_FLAG | CAN_SFF_MASK,
+				.can_mask = CAN_EFF_FLAG | CAN_RTR_FLAG | CAN_EFF_MASK,
 			},
 		};
 


### PR DESCRIPTION
Also use `can0` as default interface.