### PR TITLE
mcp251xfd-regmap: fix compiler warning

### DIFF
--- a/mcp251xfd/mcp251xfd-regmap.c
+++ b/mcp251xfd/mcp251xfd-regmap.c
@@ -35,7 +35,11 @@ do_mcp251xfd_regmap_read(struct mcp251xfd_priv *priv,
 
 	while ((ret = fscanf(reg_file, "%hx: %x\n", &reg, &val)) != EOF) {
 		if (ret != 2) {
-			fscanf(reg_file, "%*[^\n]\n");
+			int tmp;
+
+			tmp = fscanf(reg_file, "%*[^\n]\n");
+			(void)tmp;
+
 			continue;
 		}
 


### PR DESCRIPTION
Fix the following compiler warning:

```
mcp251xfd/mcp251xfd-regmap.c:38:4: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
                        fscanf(reg_file, "%*[^\n]\n");
                        ^~~~~~ ~~~~~~~~~~~~~~~~~~~~~
```

Reported-by: https://github.com/Chaitanya84
Link: https://github.com/linux-can/can-utils/pull/506