### PR TITLE
isobusfs: fix clang warnings

### DIFF
--- a/isobusfs/isobusfs_srv_fa.c
+++ b/isobusfs/isobusfs_srv_fa.c
@@ -348,8 +348,8 @@ static int isobusfs_srv_fa_open_file_req(struct isobusfs_srv_priv *priv,
 	uint8_t error_code = 0;
 	uint8_t access_type;
 	size_t abs_path_len;
+	uint8_t handle = 0;
 	char *abs_path;
-	uint8_t handle;
 	int ret = 0;
 
 	client = isobusfs_srv_get_client_by_msg(priv, msg);
@@ -502,8 +502,6 @@ static int isobusfs_srv_read_directory(struct isobusfs_srv_handles *handle,
 	DIR *dir = handle->dir;
 	struct dirent *entry;
 	size_t pos = 0;
-	size_t entry_count = 0;
-
 
 	/*
 	 * Position the directory stream to the previously stored offset (handle->dir_pos).
@@ -596,8 +594,6 @@ static int isobusfs_srv_read_directory(struct isobusfs_srv_handles *handle,
 		size = htole32(file_stat.st_size);
 		memcpy(buffer + pos, &size, sizeof(size));
 		pos += sizeof(size);
-
-		entry_count++;
 	}
 
 	*readed_size = pos;


### PR DESCRIPTION
Fix following clang warnings:
```
  CC       isobusfs/isobusfs_srv_fa.o
  isobusfs/isobusfs_srv_fa.c:387:6: warning: variable 'handle' is used
  uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
        if (ret < 0) {
            ^~~~~~~
  isobusfs/isobusfs_srv_fa.c:411:15: note: uninitialized use occurs here
        res.handle = handle;
                     ^~~~~~
  isobusfs/isobusfs_srv_fa.c:387:2: note: remove the 'if' if its condition is
  always false
        if (ret < 0) {
        ^~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:368:6: warning: variable 'handle' is used
  uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
        if (name_len > ISOBUSFS_MAX_PATH_NAME_LENGTH) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:411:15: note: uninitialized use occurs here
        res.handle = handle;
                     ^~~~~~
  isobusfs/isobusfs_srv_fa.c:368:2: note: remove the 'if' if its condition is
  always false
        if (name_len > ISOBUSFS_MAX_PATH_NAME_LENGTH) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:362:6: warning: variable 'handle' is used
  uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
        if (name_len > msg->len - sizeof(*req)) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:411:15: note: uninitialized use occurs here
        res.handle = handle;
                     ^~~~~~
  isobusfs/isobusfs_srv_fa.c:362:2: note: remove the 'if' if its condition is
  always false
        if (name_len > msg->len - sizeof(*req)) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:356:6: warning: variable 'handle' is used
  uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
        if (!client) {
            ^~~~~~~
  isobusfs/isobusfs_srv_fa.c:411:15: note: uninitialized use occurs here
        res.handle = handle;
                     ^~~~~~
  isobusfs/isobusfs_srv_fa.c:356:2: note: remove the 'if' if its condition is
  always false
        if (!client) {
        ^~~~~~~~~~~~~~
  isobusfs/isobusfs_srv_fa.c:352:16: note: initialize the variable 'handle' to
  silence this warning
        uint8_t handle;
                      ^
                       = '\0'
  isobusfs/isobusfs_srv_fa.c:505:9: warning: variable 'entry_count' set but not
  used [-Wunused-but-set-variable]
        size_t entry_count = 0;
               ^
  5 warnings generated.
```