### PR TITLE
can-utils: fix sign-compare warnings

### DIFF
--- a/include/linux/can.h
+++ b/include/linux/can.h
@@ -218,10 +218,10 @@ struct canxl_frame {
 	__u8    data[CANXL_MAX_DLEN];
 };
 
-#define CAN_MTU		(sizeof(struct can_frame))
-#define CANFD_MTU	(sizeof(struct canfd_frame))
-#define CANXL_MTU	(sizeof(struct canxl_frame))
-#define CANXL_HDR_SIZE	(offsetof(struct canxl_frame, data))
+#define CAN_MTU		(int)(sizeof(struct can_frame))
+#define CANFD_MTU	(int)(sizeof(struct canfd_frame))
+#define CANXL_MTU	(int)(sizeof(struct canxl_frame))
+#define CANXL_HDR_SIZE	(int)(offsetof(struct canxl_frame, data))
 #define CANXL_MIN_MTU	(CANXL_HDR_SIZE + 64)
 #define CANXL_MAX_MTU	CANXL_MTU
 

--- a/lib.c
+++ b/lib.c
@@ -522,7 +522,7 @@ int snprintf_long_canframe(char *buf, size_t size, cu_t *cu, int view)
 		}
 	}
 
-	if (maxsize > size - 1) {
+	if (maxsize > (int)size - 1) {
 		/* mark buffer overflow in output */
 		memset(buf, '-', size - 1);
 		buf[size - 1] = 0;


### PR DESCRIPTION
Fixing following build issues seen when building with clang (AOSP14):
```
cansend.c:168:11: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                if (mtu >= CANXL_MIN_MTU) {
                    ~~~ ^  ~~~~~~~~~~~~~
lib.c:525:14: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
        if (maxsize > size - 1) {
            ~~~~~~~ ^ ~~~~~~~~
cangen.c:777:29: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                if (canxl && (ifr.ifr_mtu < CANXL_MIN_MTU)) {
                              ~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
cangen.c:782:29: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                if (canfd && (ifr.ifr_mtu < CANFD_MTU)) {
                              ~~~~~~~~~~~ ^ ~~~~~~~~~
cangen.c:796:19: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                if (ifr.ifr_mtu >= CANXL_MIN_MTU) {
                    ~~~~~~~~~~~ ^  ~~~~~~~~~~~~~
cangen.c:1073:20: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                        if (ifr.ifr_mtu >= CANXL_MIN_MTU)
                            ~~~~~~~~~~~ ^  ~~~~~~~~~~~~~
candump.c:758:15: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
                        if (nbytes < CANXL_HDR_SIZE + CANXL_MIN_DLEN) {
                            ~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```