### PR TITLE
can-utils: fix sign-compare warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ PREFIX ?= /usr/local
 
 MAKEFLAGS := -k
 
-CFLAGS := -O2 -Wall -Wno-parentheses
+CFLAGS := -O2 -Wall -Wno-parentheses -Wsign-compare
 
 HAVE_FORK := $(shell ./check_cc.sh "$(CC)" fork_test.c)
 

--- a/candump.c
+++ b/candump.c
@@ -755,13 +755,13 @@ int main(int argc, char **argv)
 			}
 
 			/* mark dual-use struct canfd_frame */
-			if (nbytes < CANXL_HDR_SIZE + CANXL_MIN_DLEN) {
+			if (nbytes < (int)CANXL_HDR_SIZE + CANXL_MIN_DLEN) {
 				fprintf(stderr, "read: no CAN frame\n");
 				return 1;
 			}
 
 			if (cu.xl.flags & CANXL_XLF) {
-				if (nbytes != CANXL_HDR_SIZE + cu.xl.len) {
+				if (nbytes != (int)CANXL_HDR_SIZE + cu.xl.len) {
 					printf("nbytes = %d\n", nbytes);
 					fprintf(stderr, "read: no CAN XL frame\n");
 					return 1;

--- a/canfdtest.c
+++ b/canfdtest.c
@@ -215,11 +215,12 @@ static int recv_frame(struct canfd_frame *frame, int *flags)
 	ssize_t ret;
 
 	ret = recvmsg(sockfd, &msg, 0);
-	if (ret != iov.iov_len) {
-		if (ret < 0)
-			perror("recvmsg() failed");
-		else
-			fprintf(stderr, "recvmsg() returned %zd", ret);
+	if (ret < 0) {
+		perror("recvmsg() failed");
+		return -1;
+	}
+	if ((size_t)ret != iov.iov_len) {
+		fprintf(stderr, "recvmsg() returned %zd", ret);
 		return -1;
 	}
 

--- a/cangen.c
+++ b/cangen.c
@@ -774,17 +774,17 @@ int main(int argc, char **argv)
 				cu.fd.len = CANFD_MAX_DLEN;
 		}
 
-		if (canxl && (ifr.ifr_mtu < CANXL_MIN_MTU)) {
+		if (canxl && (ifr.ifr_mtu < (int)CANXL_MIN_MTU)) {
 			printf("CAN interface not CAN XL capable - sorry.\n");
 			return 1;
 		}
 
-		if (canfd && (ifr.ifr_mtu < CANFD_MTU)) {
+		if (canfd && (ifr.ifr_mtu < (int)CANFD_MTU)) {
 			printf("CAN interface not CAN FD capable - sorry.\n");
 			return 1;
 		}
 
-		if (ifr.ifr_mtu == CANFD_MTU) {
+		if (ifr.ifr_mtu == (int)CANFD_MTU) {
 			/* interface is ok - try to switch the socket into CAN FD mode */
 			if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,
 				       &enable_canfx, sizeof(enable_canfx))){
@@ -793,7 +793,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		if (ifr.ifr_mtu >= CANXL_MIN_MTU) {
+		if (ifr.ifr_mtu >= (int)CANXL_MIN_MTU) {
 			/* interface is ok - try to switch the socket into CAN XL mode */
 			if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_XL_FRAMES,
 				       &enable_canfx, sizeof(enable_canfx))){
@@ -1070,7 +1070,7 @@ int main(int argc, char **argv)
 				esi = i & 8;
 			}
 			/* generate CAN XL traffic if the interface is capable */
-			if (ifr.ifr_mtu >= CANXL_MIN_MTU)
+			if (ifr.ifr_mtu >= (int)CANXL_MIN_MTU)
 				canxl = ((i & 96) == 96);
 
 			rtr_frame = ((i & 24) == 24); /* reduce RTR frames to 1/4 */

--- a/canlogserver.c
+++ b/canlogserver.c
@@ -407,13 +407,13 @@ int main(int argc, char **argv)
 					return 1;
 				}
 
-				if (nbytes < CANXL_HDR_SIZE + CANXL_MIN_DLEN) {
+				if (nbytes < (int)CANXL_HDR_SIZE + CANXL_MIN_DLEN) {
 					fprintf(stderr, "read: no CAN frame\n");
 					return 1;
 				}
 
 				if (cu.xl.flags & CANXL_XLF) {
-					if (nbytes != CANXL_HDR_SIZE + cu.xl.len) {
+					if (nbytes != (int)CANXL_HDR_SIZE + cu.xl.len) {
 						printf("nbytes = %d\n", nbytes);
 						fprintf(stderr, "read: no CAN XL frame\n");
 						return 1;

--- a/cansend.c
+++ b/cansend.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 		}
 		mtu = ifr.ifr_mtu;
 
-		if (mtu == CANFD_MTU) {
+		if (mtu == (int)CANFD_MTU) {
 			/* interface is ok - try to switch the socket into CAN FD mode */
 			if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,
 				       &enable_canfx, sizeof(enable_canfx))){
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		if (mtu >= CANXL_MIN_MTU) {
+		if (mtu >= (int)CANXL_MIN_MTU) {
 			/* interface is ok - try to switch the socket into CAN XL mode */
 			if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_XL_FRAMES,
 				       &enable_canfx, sizeof(enable_canfx))){

--- a/isobusfs/isobusfs_cli.c
+++ b/isobusfs/isobusfs_cli.c
@@ -268,10 +268,10 @@ static int isobusfs_cli_rx_one(struct isobusfs_priv *priv, int sock)
 	return 0;
 }
 
-static int isobusfs_cli_handle_events(struct isobusfs_priv *priv, int nfds)
+static int isobusfs_cli_handle_events(struct isobusfs_priv *priv, unsigned int nfds)
 {
 	int ret;
-	int n;
+	unsigned int n;
 
 	for (n = 0; n < nfds && n < priv->cmn.epoll_events_size; ++n) {
 		struct epoll_event *ev = &priv->cmn.epoll_events[n];
@@ -341,7 +341,7 @@ int isobusfs_cli_process_events_and_tasks(struct isobusfs_priv *priv)
 		return ret;
 
 	if (nfds > 0) {
-		ret = isobusfs_cli_handle_events(priv, nfds);
+		ret = isobusfs_cli_handle_events(priv, (unsigned int)nfds);
 		if (ret)
 			return ret;
 	}

--- a/isobusfs/isobusfs_cmn.c
+++ b/isobusfs/isobusfs_cmn.c
@@ -823,7 +823,7 @@ void isobusfs_cmn_dump_last_x_bytes(const uint8_t *buffer, size_t buffer_size,
 	size_t start_offset = 0;
 	char *output_ptr;
 	unsigned char c;
-	size_t remaining;
+	int remaining;
 	char output[80];
 	int n, j;
 
@@ -832,7 +832,7 @@ void isobusfs_cmn_dump_last_x_bytes(const uint8_t *buffer, size_t buffer_size,
 
 	for (size_t i = start_offset; i < buffer_size; i += 8) {
 		output_ptr = output;
-		remaining = sizeof(output);
+		remaining = (int)sizeof(output);
 
 		n = snprintf(output_ptr, remaining, "%08lx: ",
 			     (unsigned long)(start_offset + i));

--- a/isobusfs/isobusfs_srv.c
+++ b/isobusfs/isobusfs_srv.c
@@ -201,10 +201,10 @@ done:
 	return EXIT_SUCCESS;
 }
 
-static int isobusfs_srv_handle_events(struct isobusfs_srv_priv *priv, int nfds)
+static int isobusfs_srv_handle_events(struct isobusfs_srv_priv *priv, unsigned int nfds)
 {
 	int ret;
-	int n;
+	unsigned int n;
 
 	for (n = 0; n < nfds && n < priv->cmn.epoll_events_size; ++n) {
 		struct epoll_event *ev = &priv->cmn.epoll_events[n];

--- a/isobusfs/isobusfs_srv_cm.c
+++ b/isobusfs/isobusfs_srv_cm.c
@@ -36,7 +36,7 @@ int isobusfs_srv_request_volume(struct isobusfs_srv_priv *priv,
 				struct isobusfs_srv_client *client,
 				struct isobusfs_srv_volume *volume)
 {
-	int j;
+	unsigned int j;
 
 	/* Check if the client already requested this volume */
 	for (j = 0; j < ARRAY_SIZE(volume->clients); j++) {

--- a/isobusfs/isobusfs_srv_dh.c
+++ b/isobusfs/isobusfs_srv_dh.c
@@ -110,7 +110,7 @@ int isobusfs_path_to_linux_path(struct isobusfs_srv_priv *priv,
 
 		ptr++;
 		vol_end++;
-		if (ptr - linux_path >= linux_path_size) {
+		if (ptr - linux_path >= (long int)linux_path_size) {
 			/* Ensure null termination */
 			linux_path[linux_path_size - 1] = '\0';
 			break;

--- a/isobusfs/isobusfs_srv_fa.c
+++ b/isobusfs/isobusfs_srv_fa.c
@@ -16,7 +16,7 @@
 static struct isobusfs_srv_handles *
 isobusfs_srv_walk_handles(struct isobusfs_srv_priv *priv, const char *path)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(priv->handles); i++) {
 		if (priv->handles[i].path == NULL)
@@ -32,9 +32,9 @@ isobusfs_srv_walk_handles(struct isobusfs_srv_priv *priv, const char *path)
 static int isobusfs_srv_add_file(struct isobusfs_srv_priv *priv,
 				 const char *path, int fd, DIR *dir)
 {
-	int j;
+	unsigned int j;
 
-	if (priv->handles_count >= ARRAY_SIZE(priv->handles)) {
+	if (priv->handles_count >= (int)ARRAY_SIZE(priv->handles)) {
 		pr_err("too many handles");
 		return -ENOSPC;
 	}
@@ -55,7 +55,7 @@ static int isobusfs_srv_add_file(struct isobusfs_srv_priv *priv,
 static int isobusfs_srv_add_client_to_file(struct isobusfs_srv_handles *file,
 					   struct isobusfs_srv_client *client)
 {
-	int j;
+	unsigned int j;
 
 	for (j = 0; j < ARRAY_SIZE(file->clients); j++) {
 		if (file->clients[j] == client)
@@ -102,7 +102,7 @@ static int isobusfs_srv_request_file(struct isobusfs_srv_priv *priv,
 static struct isobusfs_srv_handles *
 isobusfs_srv_get_handle(struct isobusfs_srv_priv *priv, int handle)
 {
-	if (handle < 0 || handle >= ARRAY_SIZE(priv->handles))
+	if (handle < 0 || handle >= (int)ARRAY_SIZE(priv->handles))
 		return NULL;
 
 	return &priv->handles[handle];
@@ -113,7 +113,7 @@ static int isobusfs_srv_release_handle(struct isobusfs_srv_priv *priv,
 				       int handle)
 {
 	struct isobusfs_srv_handles *hdl = isobusfs_srv_get_handle(priv, handle);
-	int client_index;
+	unsigned int client_index;
 
 	if (!hdl) {
 		pr_warn("%s: invalid handle %d", __func__, handle);
@@ -152,8 +152,8 @@ static int isobusfs_srv_release_handle(struct isobusfs_srv_priv *priv,
 void isobusfs_srv_remove_client_from_handles(struct isobusfs_srv_priv *priv,
 					   struct isobusfs_srv_client *client)
 {
-	int handle;
-	int client_index;
+	unsigned int handle;
+	unsigned int client_index;
 
 	for (handle = 0; handle < ARRAY_SIZE(priv->handles); handle++) {
 		struct isobusfs_srv_handles *hdl = &priv->handles[handle];
@@ -488,7 +488,7 @@ static int check_access_with_base(const char *base_dir,
 	char full_path[ISOBUSFS_SRV_MAX_PATH_LEN];
 
 	if (snprintf(full_path, sizeof(full_path), "%s/%s", base_dir,
-		 relative_path) >= sizeof(full_path)) {
+		     relative_path) >= (int)sizeof(full_path)) {
 		return -ENAMETOOLONG;
 	}
 
@@ -519,7 +519,7 @@ static int isobusfs_srv_read_directory(struct isobusfs_srv_handles *handle,
 	 *   either returning an error or restarting from the beginning of the directory, depending
 	 *   on the application's requirements.
 	 */
-	for (size_t i = 0; i < handle->dir_pos &&
+	for (int i = 0; i < handle->dir_pos &&
 	     (entry = readdir(dir)) != NULL; i++) {
 		/* Iterating to the desired position */
 	}

--- a/lib.c
+++ b/lib.c
@@ -437,7 +437,8 @@ int snprintf_long_canframe(char *buf, size_t size, cu_t *cu, int view)
 	/* documentation see lib.h */
 
 	unsigned char is_canfd = cu->fd.flags;
-	int i, j, dlen, offset, maxsize;
+	int i, j, dlen, offset;
+	size_t maxsize;
 	int len;
 
 	/* ensure space for string termination */

--- a/slcanpty.c
+++ b/slcanpty.c
@@ -53,13 +53,13 @@
 static int pty2can(int pty, int socket, struct can_filter *fi,
 		   int *is_open, int *tstamp)
 {
-	unsigned int nbytes;
+	unsigned int nbytes, tmp;
 	char cmd;
 	static char buf[200];
 	char replybuf[10]; /* for answers to received commands */
-	int ptr;
+	unsigned int ptr;
 	struct can_frame frame;
-	int ret, tmp, i;
+	int ret, i;
 	static unsigned int rxoffset = 0; /* points to the end of an received incomplete SLCAN message */
 
 	ret = read(pty, &buf[rxoffset], sizeof(buf) - rxoffset - 1);
@@ -282,8 +282,8 @@ rx_restart:
 			ptr--;
 	}
 
-	tmp = write(socket, &frame, sizeof(frame));
-	if (tmp != sizeof(frame)) {
+	ret = write(socket, &frame, sizeof(frame));
+	if (ret != sizeof(frame)) {
 		perror("write socket");
 		return 1;
 	}
@@ -296,8 +296,8 @@ rx_out_nack:
 	replybuf[0] = '\a';
 	tmp = 1;
 rx_out:
-	tmp = write(pty, replybuf, tmp);
-	if (tmp < 0) {
+	ret = write(pty, replybuf, tmp);
+	if (ret < 0) {
 		perror("write pty replybuf");
 		return 1;
 	}


### PR DESCRIPTION
Fixing several build issues reported by Gary Bisson when he was building can-utils with clang (AOSP14).

URL: https://github.com/linux-can/can-utils/pull/512
Reported-by: Gary Bisson (https://github.com/gibsson)