### PR TITLE
can-calc-bit-timing: in case of invalid option exit with error

### DIFF
--- a/calc-bit-timing/can-calc-bit-timing.c
+++ b/calc-bit-timing/can-calc-bit-timing.c
@@ -1514,11 +1514,6 @@ int main(int argc, char *argv[])
 			data->verbose = true;
 			break;
 
-		case '?':
-			print_usage(basename(argv[0]));
-			exit(EXIT_SUCCESS);
-			break;
-
 		case OPT_TQ:
 			opt_bt->tq = strtoul(optarg, NULL, 10);
 			break;


### PR DESCRIPTION
Link: https://github.com/linux-can/can-utils/issues/518
Reported-by: https://github.com/EnricoMontecaggi
Fixes: f4a9e5b57def ("can-calc-bit-timing.c: Reformat help/usage output to be compatible with help2man.")