### PR TITLE
bcmserver: use pragma to silence unknown pragma option

### DIFF
--- a/bcmserver.c
+++ b/bcmserver.c
@@ -156,6 +156,7 @@ int main(void)
 	char rxmsg[50];
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
 	struct {
 		struct bcm_msg_head msg_head;


### PR DESCRIPTION
Silence the following warning by switching it of via a pragma.

| bcmserver.c: In function 'main':
| bcmserver.c:159:32: warning: unknown option after '#pragma GCC diagnostic' kind [-Wpragmas]
|   159 | #pragma GCC diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
|       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Closes: https://github.com/linux-can/can-utils/issues/536