### PR TITLE
isobusfs: address snprintf truncation warning with explicit limits

### DIFF
--- a/isobusfs/isobusfs_cmn.c
+++ b/isobusfs/isobusfs_cmn.c
@@ -101,7 +101,7 @@ void isobusfs_log(log_level_t level, const char *fmt, ...)
 	va_end(args);
 
 	snprintf(complete_log_entry, sizeof(complete_log_entry),
-		 "[%s] [%s]: %s", time_buffer, level_str, log_entry);
+		 "[%.40s] [%.10s]: %.150s", time_buffer, level_str, log_entry);
 
 	if (interactive_mode) {
 		add_log_to_buffer(complete_log_entry);


### PR DESCRIPTION
Modify the isobusfs_log function in isobusfs_cmn.c to explicitly limit the lengths of the time_buffer, level_str, and log_entry strings in the snprintf format string to 40, 10, and 150 characters respectively. This change acknowledges that truncation may still occur, but it is now explicit and controlled.

This change silences the following warning:
```
cmake -DCMAKE_BUILD_TYPE=Debug -D CMAKE_C_COMPILER=gcc -B build
cmake --build build

/home/isobusfs/isobusfs_cmn.c: In function 'isobusfs_log': /home/isobusfs/isobusfs_cmn.c:104:30: warning: '%s' directive output may be truncated writing up to 191 bytes into a region of size between 182 and 245 [-Wformat-truncation=]
  104 |                  "[%s] [%s]: %s", time_buffer, level_str, log_entry);
      |                              ^~                           ~~~~~~~~~
/home/isobusfs/isobusfs_cmn.c:103:9: note: 'snprintf' output 12 or more
bytes (assuming 266) into a destination of size 256
  103 |         snprintf(complete_log_entry, sizeof(complete_log_entry),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  104 |                  "[%s] [%s]: %s", time_buffer, level_str, log_entry);
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Closes: https://github.com/linux-can/can-utils/issues/535