### PR TITLE
asc2log::get_date check for AM in en_US time format

### DIFF
--- a/asc2log.c
+++ b/asc2log.c
@@ -384,7 +384,7 @@ static int get_date(struct timeval *tv, char *date)
 	struct tm tms;
 	unsigned int msecs = 0;
 
-	if (strcasestr(date, " pm ") != NULL) {
+	if ((strcasestr(date, " am ") != NULL) || (strcasestr(date, " pm ") != NULL)) {
 		/* assume EN/US date due to existing am/pm field */
 
 		if (!setlocale(LC_TIME, "en_US")) {


### PR DESCRIPTION
the get_date function misses a case when the date line having AM in timestamp. This PR fixes that problem by finding ` am ` in the date string.