### PR TITLE
j1939acd: fix uclibc compile (const char* program_invocation_name)

### DIFF
--- a/j1939acd.c
+++ b/j1939acd.c
@@ -485,12 +485,16 @@ int main(int argc, char *argv[])
 			s.current_sa = strtoul(optarg, 0, 0);
 			break;
 		case 'p':
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && !defined(__UCLIBC__)
 			if (asprintf(&program_invocation_name, "%s.%s",
 				     program_invocation_short_name, optarg) < 0)
 				err(1, "asprintf(program invocation name)");
 #else
+#if defined(__UCLIBC__)
+			err(0, "option -p disabled with uclibc");
+#else
 			err(0, "compile with -D_GNU_SOURCE to use -p");
+#endif
 #endif
 			break;
 		default:


### PR DESCRIPTION
- disable command line option '-p' in case of uclibc

Fixes:
```
  j1939acd.c: In function 'main': j1939acd.c:489:38: error: passing argument 1 of 'asprintf' from incompatible pointer type [-Wincompatible-pointer-types]
    489 |                         if (asprintf(&program_invocation_name, "%s.%s",
        |                                      ^~~~~~~~~~~~~~~~~~~~~~~~
        |                                      |
        |                                      const char **
```