### PR TITLE
README: update link to kernel documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Follow the link to see examples on how this tools can be used:
 
 ### Additional Information:
 
-*   [SocketCAN Documentation (Linux Kernel)](https://www.kernel.org/doc/Documentation/networking/can.txt)
+*   [SocketCAN Documentation (Linux Kernel)](https://www.kernel.org/doc/html/latest/networking/can.html)
 *   [Elinux.org CAN Bus Page](http://elinux.org/CAN_Bus)
 *   [Debian Package Description](https://packages.debian.org/sid/can-utils)
 


### PR DESCRIPTION
The can.txt is obsolete, move to rendered html instead.