### PR TITLE
Fix and rework canbusload

### DIFF
--- a/canbusload.c
+++ b/canbusload.c
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
 		ptr = argv[optind + i];
 
 		nbytes = strlen(ptr);
-		if (nbytes >= (int)(IFNAMSIZ + sizeof("@1000000") + 1)) {
+		if (nbytes >= (int)(IFNAMSIZ + sizeof("@1000000,2000000") + 1)) {
 			printf("name of CAN device '%s' is too long!\n", ptr);
 			return 1;
 		}


### PR DESCRIPTION
- rework to use a single CAN socket for the received CAN traffic.
This allows to shutdown and restart various CAN interfaces without
terminating the application.
Additionally an auto detection has been implemented with the 'any' CAN
interface. E.g. with any@500000,2000000 CAN interfaces that have not
been defined before are assigned with the given 'any' bitrates when a
CAN frame from this CAN interface has been received.

- show RX/TX direction in bargraph
- fix and improve the bitrate output
