### PR TITLE
Include time.h for timespec struct definition

### DIFF
--- a/libj1939.h
+++ b/libj1939.h
@@ -17,6 +17,7 @@
 #include <linux/can/j1939.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <time.h>
 #include <sys/socket.h>
 
 #ifndef J1939_LIB_H


### PR DESCRIPTION
Fixes
git/isobusfs/../libj1939.h:33:18: error: field has incomplete type 'struct timespec'
   33 |         struct timespec next_send_time;
      |                         ^
Signed-off-by: Khem Raj <raj.khem@gmail.com>