### PR TITLE
isobusfs: fix typos

### DIFF
--- a/isobusfs/isobusfs_cli_int.c
+++ b/isobusfs/isobusfs_cli_int.c
@@ -1077,7 +1077,7 @@ int isobusfs_cli_interactive(struct isobusfs_priv *priv)
 			}
 		}
 
-		pr_int("unknown comand\n");
+		pr_int("unknown command\n");
 		isobusfs_cli_promt(priv);
 	} else {
 		if (errno != EAGAIN && errno != EWOULDBLOCK)

--- a/isobusfs/isobusfs_cli_selftests.c
+++ b/isobusfs/isobusfs_cli_selftests.c
@@ -211,7 +211,7 @@ static struct isobusfs_cli_test_dir_path test_dir_patterns[] = {
 	{ "~tilde_dir", true },
 	/* expected result \\vol1\dir1\~\ */
 	{ "\\\\vol1\\dir1\\~", true },
-	/* expected result \\vol1\~\ not clear if it is manufacture speficic dir */
+	/* expected result \\vol1\~\ not clear if it is manufacture specific dir */
 	{ "\\~\\", true },
 	/* expected result \\~\ */
 	{ "\\\\~\\", false },

--- a/isobusfs/isobusfs_cmn.c
+++ b/isobusfs/isobusfs_cmn.c
@@ -611,7 +611,7 @@ int isobusfs_cmn_connect_socket(int sock, struct sockaddr_can *addr)
 }
 
 /* FIXME: linger is currently not supported by the kernel J1939 stack
- * but it would be nice to have it. Especially if we wont to stop sending
+ * but it would be nice to have it. Especially if we won't to stop sending
  * messages on a socket when the connection is lost.
  */
 int isobusfs_cmn_set_linger(int sock)

--- a/isobusfs/isobusfs_cmn_dh.c
+++ b/isobusfs/isobusfs_cmn_dh.c
@@ -23,7 +23,7 @@ int isobusfs_cmn_dh_validate_dir_path(const char *path, bool writable)
 	ret = access(path, mode);
 	if (ret == -1) {
 		ret = -errno;
-		pr_err("failed to acces path %s, for read %s. %s", path,
+		pr_err("failed to access path %s, for read %s. %s", path,
 		       writable ? "and write" : "", strerror(ret));
 		return ret;
 	}

--- a/isobusfs/isobusfs_srv.c
+++ b/isobusfs/isobusfs_srv.c
@@ -70,7 +70,7 @@ static int isobusfs_srv_rx_fs(struct isobusfs_srv_priv *priv,
 		      cg);
 
 		/* ISO 11783-13:2021 - Annex C.1.1 Overview:
-		 * If a client sends a command, which is not defined withing this
+		 * If a client sends a command, which is not defined within this
 		 * documentation, the file server shall respond with a
 		 * NACK (ISO 11783-3:2018 Chapter 5.4.5)
 		 */
@@ -279,7 +279,7 @@ static int isobusfs_srv_sock_fss_prepare(struct isobusfs_srv_priv *priv)
 		return ret;
 
 	/* keep address and name and overwrite PGN */
-	/* TOOD: actually, this is PGN input filter. Should we use different
+	/* TODO: actually, this is PGN input filter. Should we use different
 	 * PGN?
 	 */
 	addr.can_addr.j1939.pgn = ISOBUSFS_PGN_CL_TO_FS;
@@ -720,7 +720,7 @@ static int isobusfs_srv_parse_args(struct isobusfs_srv_priv *priv, int argc,
 	}
 
 	if (!local_name_set)
-		pr_warn("local name is not set. Wont be able to generate proper manufacturer-specific directory name. Falling mack to MCMC0000");
+		pr_warn("local name is not set. Won't be able to generate proper manufacturer-specific directory name. Falling mack to MCMC0000");
 	isobusfs_srv_generate_mfs_dir_name(priv);
 
 	pr_debug("Server configuration:");

--- a/isobusfs/isobusfs_srv_dh.c
+++ b/isobusfs/isobusfs_srv_dh.c
@@ -662,7 +662,7 @@ static int isobusfs_srv_dh_ccd_res(struct isobusfs_srv_priv *priv,
 	int ret;
 
 	/*
-	 * We assime, the relative path stored in res->name is not longer
+	 * We assume, the relative path stored in res->name is not longer
 	 * than absolue path
 	 */
 	if (req->name_len > ISOBUSFS_SRV_MAX_PATH_LEN) {

--- a/isobusfs/isobusfs_srv_fa.c
+++ b/isobusfs/isobusfs_srv_fa.c
@@ -686,7 +686,7 @@ send_response:
 		goto free_res;
 	}
 
-	pr_debug("> tx: Read File Response. Error code: %d (%s), readed size: %d",
+	pr_debug("> tx: Read File Response. Error code: %d (%s), read size: %d",
 		 error_code, isobusfs_error_to_str(error_code), readed_size);
 
 free_res:


### PR DESCRIPTION
Typos were found with codespell.