### PR TITLE
Makefile: remove erroneous '\'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ j1939-timedate-cli:	lib.o \
 j1939-vehicle-position-srv: \
 			lib.o \
 			libj1939.o \
-			j1939_vehicle_position/j1939_vehicle_position_srv.o \
+			j1939_vehicle_position/j1939_vehicle_position_srv.o
 		$(CC) $(LDFLAGS) $^ $(LDLIBS) -lgps -o $@
 
 isobusfs-srv:	lib.o \


### PR DESCRIPTION
This should at least fix the `No rule to make target` error:

```
cc -O2 -Wall -Wno-parentheses -Wsign-compare -I. -Iinclude -DAF_CAN=PF_CAN -DPF_CAN=29 -DSO_RXQ_OVFL=40 -DSCM_TIMESTAMPING_OPT_STATS=54 -DCLOCK_TAI=11 -DSO_TXTIME=61 -DSCM_TXTIME=SO_TXTIME -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE  -c -o j1939_vehicle_position/j1939_vehicle_position_srv.o j1939_vehicle_position/j1939_vehicle_position_srv.c
j1939_vehicle_position/j1939_vehicle_position_srv.c:7:10: fatal error: gps.h: No such file or directory
    7 | #include <gps.h>
      |          ^~~~~~~
compilation terminated.
make: *** [<builtin>: j1939_vehicle_position/j1939_vehicle_position_srv.o] Error 1
make: *** No rule to make target 'cc', needed by 'j1939-vehicle-position-srv'.
make: *** No rule to make target '-lgps', needed by 'j1939-vehicle-position-srv'.
make: *** No rule to make target '-o', needed by 'j1939-vehicle-position-srv'.
```

Link: https://github.com/linux-can/can-utils/commit/71b2aec834e74d57c643e7a6776f21a1448ef17a#commitcomment-153191516
Fixes: 71b2aec834e7 ("j1939-vehicle-position-srv: Introduce J1939 and NMEA 2000 Vehicle Position Server")