### PR TITLE
github-actions: fix used compiler

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -148,16 +148,16 @@ jobs:
 
     - name: Configure & Build with gcc (Makefile)
       env:
-        CC: gcc
+        cc: gcc
       run: |
-        podman exec -i stable make
+        podman exec -i stable make CC=${cc}
         podman exec -i stable make clean
 
     - name: Configure & Build with clang (Makefile)
       env:
-        CC: clang
+        cc: clang
       run: |
-        podman exec -i stable make
+        podman exec -i stable make CC=${cc}
         podman exec -i stable make clean
 
     - name: Show logs


### PR DESCRIPTION
Fixes: 130e0dced288 ("github-actions: compile with gcc and clang using Makefile")