### PR TITLE
can-calc-bit-timing: common_data_bitrates: add some slower bitrates

### DIFF
--- a/calc-bit-timing/can-calc-bit-timing.c
+++ b/calc-bit-timing/can-calc-bit-timing.c
@@ -1121,6 +1121,11 @@ static const unsigned int common_data_bitrates[] = {
 	4000000,
 	2000000,
 	1000000,
+	800000,
+	500000,
+	250000,
+	125000,
+	100000,
 	0
 };
 


### PR DESCRIPTION
There are real world use cases for CAN-FD data bitrates below 1 MBit/s. Add some to the `common_data_bitrates` array.

Link: https://lore.kernel.org/79BCE02A-D4EC-4362-B0D3-3FE76FB17B78@vpprocess.com