### PR TITLE
Allow more fine-grained control over CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if(ENABLE_BASIC_TOOLS)
 endif()
 
 if(ENABLE_IP_SERVER AND HAVE_FORK)
-  list(APPEND PROGRAMS        bcmserver)
+  list(APPEND PROGRAMS bcmserver)
   list(APPEND PROGRAMS_CANLIB canlogserver)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,25 @@ option(ENABLE_WERROR "Treat all compiler warnings as errors" OFF)
 option(ENABLE_GPS "Enable GPS support" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+# Options for controlling targets. These groups correspond to the README.
+option(ENABLE_BASIC_TOOLS "Build basic tools" ON)
+option(ENABLE_IP_SERVER   "Build tools providing CAN access via IP sockets" ON)
+option(ENABLE_GATEWAY     "Build in-kernel gateway configuration tools" ON)
+option(ENABLE_MEASUREMENT "Build measurement tools" ON)
+option(ENABLE_ISOTP       "Build isotp tools" ON)
+option(ENABLE_LOG_FILE    "Build log file converter tools" ON)
+option(ENABLE_SLCAN       "Build slcan tools" ON)
+option(ENABLE_MCP251XFD   "Build MCP251XFD tools" ON)
+
+# cmake_dependent_option is only available in CMake 3.22 and later.
+if(ANDROID)
+  set(ENABLE_J1939    OFF)
+  set(ENABLE_ISOBUSFS OFF)
+else()
+  option(ENABLE_J1939    "Build J1939 tools"  ON)
+  option(ENABLE_ISOBUSFS "Build ISOBUS tools" ON)
+endif()
+
 find_package(PkgConfig REQUIRED)
 if(ENABLE_GPS)
   pkg_check_modules(GPS REQUIRED libgps)
@@ -48,103 +67,111 @@ include_directories(./include)
 
 check_function_exists(fork HAVE_FORK)
 
-set(PROGRAMS_CANLIB
-  asc2log
-  canbusload
-  candump
-  cangen
-  canplayer
-  cansend
-  cansequence
-  log2asc
-  log2long
-  slcanpty
-)
+# List of all programs to be built.
+# Each program is expected to have a corresponding source file with the same name.
+set(PROGRAMS)
+# List of programs to link against can.
+set(PROGRAMS_CANLIB)
+# List of programs to link against j1939 and can.
+set(PROGRAMS_J1939)
 
-if(HAVE_FORK)
+if(ENABLE_BASIC_TOOLS)
+  list(APPEND PROGRAMS cansniffer)
+  list(APPEND PROGRAMS_CANLIB
+    candump
+    canplayer
+    cansend
+    cangen
+    cansequence
+  )
+endif()
+
+if(ENABLE_IP_SERVER AND HAVE_FORK)
+  list(APPEND PROGRAMS        bcmserver)
   list(APPEND PROGRAMS_CANLIB canlogserver)
 endif()
 
-set(PROGRAMS_J1939
-  j1939acd
-  j1939cat
-  j1939spy
-  j1939sr
-  testj1939
-)
-
-set(PROGRAMS_J1939_TIMEDATE
-  j1939-timedate-srv
-  j1939-timedate-cli
-)
-
-set(PROGRAMS_J1939_VEHICLE_POSITION
-  j1939-vehicle-position-srv
-)
-
-set(PROGRAMS_ISOBUSFS
-  isobusfs-srv
-  isobusfs-cli
-)
-
-set(PROGRAMS
-  ${PROGRAMS_CANLIB}
-  canerrsim
-  canfdtest
-  cangw
-  cansniffer
-  isotpdump
-  isotpperf
-  isotprecv
-  isotpsend
-  isotpsniffer
-  isotptun
-  slcan_attach
-  slcand
-)
-
-if(HAVE_FORK)
-  list(APPEND PROGRAMS bcmserver)
-  list(APPEND PROGRAMS isotpserver)
+if(ENABLE_GATEWAY)
+  list(APPEND PROGRAMS cangw)
 endif()
 
-add_executable(can-calc-bit-timing
-  calc-bit-timing/can-calc-bit-timing.c
-)
+if(ENABLE_MEASUREMENT)
+  list(APPEND PROGRAMS
+    canfdtest
+    canerrsim
+  )
+  list(APPEND PROGRAMS_CANLIB canbusload)
 
-add_executable(mcp251xfd-dump
-  mcp251xfd/mcp251xfd-dev-coredump.c
-  mcp251xfd/mcp251xfd-dump.c
-  mcp251xfd/mcp251xfd-main.c
-  mcp251xfd/mcp251xfd-regmap.c
-)
+  add_executable(can-calc-bit-timing
+    calc-bit-timing/can-calc-bit-timing.c
+  )
+  install(TARGETS can-calc-bit-timing DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
-if(NOT ANDROID)
-  list(APPEND PROGRAMS ${PROGRAMS_J1939})
-
-  add_library(j1939 STATIC
-    libj1939.c
+if(ENABLE_ISOTP)
+  list(APPEND PROGRAMS
+    isotpdump
+    isotpperf
+    isotprecv
+    isotpsend
+    isotpsniffer
+    isotptun
   )
 
-  target_link_libraries(j1939
-    PRIVATE can
+  if(HAVE_FORK)
+    list(APPEND PROGRAMS isotpserver)
+  endif()
+endif()
+
+if(ENABLE_J1939)
+  list(APPEND PROGRAMS_J1939
+    j1939acd
+    j1939cat
+    j1939spy
+    j1939sr
+    testj1939
   )
 
-  add_library(isobusfs
+  add_executable(j1939-timedate-cli
+    j1939_timedate/j1939_timedate_cli.c
+  )
+  target_link_libraries(j1939-timedate-cli
+    PRIVATE can j1939
+  )
+  install(TARGETS j1939-timedate-cli DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(j1939-timedate-srv
+    j1939_timedate/j1939_timedate_srv.c
+  )
+  target_link_libraries(j1939-timedate-srv
+    PRIVATE can j1939
+  )
+  install(TARGETS j1939-timedate-srv DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+if(ENABLE_J1939 AND ENABLE_GPS)
+  add_executable(j1939-vehicle-position-srv
+    j1939_vehicle_position/j1939_vehicle_position_srv.c
+  )
+  target_link_libraries(j1939-vehicle-position-srv
+    PRIVATE can j1939 ${GPS_LIBRARIES}
+  )
+  install(TARGETS j1939-vehicle-position-srv DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+if(ENABLE_ISOBUSFS)
+  add_library(isobusfs EXCLUDE_FROM_ALL
     isobusfs/isobusfs_cmn.c
     isobusfs/isobusfs_cmn_dh.c
   )
-
   set(PUBLIC_HEADER_ISOBUSFS
     isobusfs/isobusfs_cmn.h
     isobusfs/isobusfs_cmn_cm.h
   )
-
   set_target_properties(isobusfs PROPERTIES
     PUBLIC_HEADER "${PUBLIC_HEADER_ISOBUSFS}"
     SOVERSION 0
   )
-
   install(TARGETS isobusfs
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -158,10 +185,10 @@ if(NOT ANDROID)
     isobusfs/isobusfs_cli_selftests.c
     isobusfs/isobusfs_cli_int.c
   )
-
   target_link_libraries(isobusfs-cli
     PRIVATE isobusfs can j1939
   )
+  install(TARGETS isobusfs-cli DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   add_executable(isobusfs-srv
     isobusfs/isobusfs_srv.c
@@ -172,64 +199,53 @@ if(NOT ANDROID)
     isobusfs/isobusfs_srv_fh.c
     isobusfs/isobusfs_srv_vh.c
   )
-
   target_link_libraries(isobusfs-srv
     PRIVATE isobusfs can j1939
   )
-
-  install(TARGETS
-    isobusfs-cli
-    isobusfs-srv
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-  set(PUBLIC_HEADER_j1939_TIMEDATE
-    j1939_timedate/j1939_timedate_cmn.h
-  )
-
-  add_executable(j1939-timedate-cli
-    j1939_timedate/j1939_timedate_cli.c
-  )
-
-  target_link_libraries(j1939-timedate-cli
-    PRIVATE can j1939
-  )
-
-  add_executable(j1939-timedate-srv
-    j1939_timedate/j1939_timedate_srv.c
-  )
-
-  target_link_libraries(j1939-timedate-srv
-    PRIVATE can j1939
-  )
-
-  install(TARGETS
-    j1939-timedate-cli
-    j1939-timedate-srv
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-  if(ENABLE_GPS)
-    set(PUBLIC_HEADER_J1939_VEHICLE_POSITION
-      j1939_vehicle_position/j1939_vehicle_position_cmn.h
-    )
-
-    add_executable(j1939-vehicle-position-srv
-      j1939_vehicle_position/j1939_vehicle_position_srv.c
-    )
-
-    target_link_libraries(j1939-vehicle-position-srv
-      PRIVATE can j1939 ${GPS_LIBRARIES}
-    )
-
-    install(TARGETS
-      j1939-vehicle-position-srv
-      DESTINATION ${CMAKE_INSTALL_BINDIR})
-  endif()
-
+  install(TARGETS isobusfs-srv DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-add_library(can STATIC
+if(ENABLE_LOG_FILE)
+  list(APPEND PROGRAMS_CANLIB
+    asc2log
+    log2asc
+    log2long
+  )
+endif()
+
+if(ENABLE_SLCAN)
+  list(APPEND PROGRAMS
+    slcan_attach
+    slcand
+  )
+  list(APPEND PROGRAMS_CANLIB slcanpty)
+endif()
+
+if(ENABLE_MCP251XFD)
+  add_executable(mcp251xfd-dump
+    mcp251xfd/mcp251xfd-dev-coredump.c
+    mcp251xfd/mcp251xfd-dump.c
+    mcp251xfd/mcp251xfd-main.c
+    mcp251xfd/mcp251xfd-regmap.c
+  )
+  install(TARGETS mcp251xfd-dump DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+list(APPEND PROGRAMS
+  ${PROGRAMS_CANLIB}
+  ${PROGRAMS_J1939}
+)
+
+add_library(can STATIC EXCLUDE_FROM_ALL
   lib.c
   canframelen.c
+)
+
+add_library(j1939 STATIC EXCLUDE_FROM_ALL
+  libj1939.c
+)
+target_link_libraries(j1939
+  PRIVATE can
 )
 
 foreach(name ${PROGRAMS})
@@ -247,12 +263,6 @@ foreach(name ${PROGRAMS})
 
   install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach()
-
-install(TARGETS
-  can-calc-bit-timing
-  mcp251xfd-dump
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
 
 add_custom_target(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/make_uninstall.cmake"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ subsystem (aka SocketCAN):
 Follow the link to see examples on how this tools can be used:
 [Kickstart guide to can-j1939 on linux](https://github.com/linux-can/can-utils/blob/master/can-j1939-kickstart.md)
 
+#### ISOBus File server tools
+* isobusfs-cli : ISOBus file client
+* isobusfs-srv : ISOBus file server
+
 #### Log file converters
 * asc2log : convert ASC logfile to compact CAN frame logfile
 * log2asc : convert compact CAN frame logfile to ASC logfile


### PR DESCRIPTION
Currently the CMake build is either all or nothing. You have explicit control over which targets are built using `cmake --build --target <xyz>`, but this doesn't apply to install step.
Running `cmake --install` will currently always install all available targets.

This PR adds the same groups that are present in the README to the CMake build, allowing you to control them individually. By default everything is turned on, which means there should be no differences compared to before.
