### PR TITLE
lib.h: include linux/can.h

### DIFF
--- a/lib.h
+++ b/lib.h
@@ -49,6 +49,8 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#include <linux/can.h>
+
 #ifdef DEBUG
 #define pr_debug(fmt, args...) printf(fmt, ##args)
 #else


### PR DESCRIPTION
Make `lib.h` self contained, so that language servers can parse it without errors.