### PR TITLE
Add minimal release workflow with Ubuntu deb building

### DIFF
--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -1,0 +1,57 @@
+name: Build Deb Package
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v6
+      with:
+        path: can-utils
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential devscripts debhelper cmake equivs
+
+        cd can-utils
+        # Install build dependencies defined in debian/control
+        sudo mk-build-deps -i -r -t "apt-get -y" debian/control
+
+    - name: Update changelog
+      run: |
+        cd can-utils
+        # Get version from tag, strip 'v' prefix if present
+        VERSION=${{ github.event.release.tag_name }}
+        VERSION=${VERSION#v}
+
+        # Add new entry to changelog
+        # Use the codename of the current OS (jammy or noble)
+        CODENAME=$(lsb_release -cs)
+
+        dch --create -v "${VERSION}-1~${CODENAME}" --package can-utils --distribution ${CODENAME} "New upstream release ${VERSION}"
+        dch -r ""
+
+    - name: Build package
+      run: |
+        cd can-utils
+        # Build binary packages only, unsigned
+        dpkg-buildpackage -us -uc -b
+
+    - name: Upload to Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          *.deb

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+can-utils (0.0.0-1) unstable; urgency=medium
+
+  * Initial release.
+
+ -- Maintainer Name <maintainer@example.com>  Thu, 01 Jan 1970 00:00:00 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,23 @@
+Source: can-utils
+Section: net
+Priority: optional
+Maintainer: GitHub Actions <actions@github.com>
+Build-Depends: debhelper-compat (= 13), cmake
+Standards-Version: 4.6.2
+Homepage: https://github.com/linux-can/can-utils
+
+Package: can-utils
+Architecture: linux-any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: SocketCAN userspace utilities and tools
+ This package contains some userspace utilities for Linux SocketCAN subsystem.
+
+ Basic tools to display, record, generate and replay CAN traffic:
+ candump, canplayer, cansend, cangen, cansniffer, cansequence.
+ CAN access via IP sockets: canlogserver, bcmserver.
+ CAN in-kernel gateway configuration: cangw.
+ CAN bus measurement and testing: canbusload, can-calc-bit-timing, canfdtest, canerrsim.
+ ISO-TP tools: isotpsend, isotprecv, isotpsniffer, isotpdump, isotpserver, isotptun.
+ CAN log file converters: asc2log, log2asc, log2long.
+ Serial Line Discipline configuration: slcan_attach, slcand, slcanpty.
+ J1939 tools: j1939acd, j1939cat, j1939spy, j1939sr, testj1939.

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,3 @@
+#!/usr/bin/make -f
+%:
+	dh $@


### PR DESCRIPTION
Add a minimal poc release workflow with Ubuntu deb building.

Fixes https://github.com/linux-can/can-utils/issues/610

