### PR TITLE
J1939: VP1/VP2 PG fixes

### DIFF
--- a/j1939_vehicle_position/j1939_vehicle_position_cmn.h
+++ b/j1939_vehicle_position/j1939_vehicle_position_cmn.h
@@ -63,8 +63,8 @@ struct j1939_vp_err_msg {
  *           - Data Length: 4 bytes
  *           - Resolution: 10^-7 deg/bit
  *           - Offset: -210 degrees
- *           - Range: -210 to +211.1008122 degrees
- *           - Operating Range: -210 degrees (SOUTH) to +211.108122 degrees
+ *           - Range: -210 to +211.10081215 degrees
+ *           - Operating Range: -210 degrees (SOUTH) to +211.1081215 degrees
  *             (NORTH)
  *
  * @longitude: Raw longitude position of the vehicle
@@ -72,8 +72,8 @@ struct j1939_vp_err_msg {
  *           - Data Length: 4 bytes
  *           - Resolution: 10^-7 deg/bit
  *           - Offset: -210 degrees
- *           - Range: -210 to +211.1008122 degrees
- *           - Operating Range: -210 degrees (WEST) to +211.108122 degrees
+ *           - Range: -210 to +211.10081215 degrees
+ *           - Operating Range: -210 degrees (WEST) to +211.1081215 degrees
  *             (EAST)
  *
  * This structure defines each component of the Vehicle Position as described in

--- a/j1939_vehicle_position/j1939_vehicle_position_cmn.h
+++ b/j1939_vehicle_position/j1939_vehicle_position_cmn.h
@@ -142,42 +142,48 @@ j1939_vp1_set_longitude(struct j1939_vp1_packet *packet, int32_t longitude)
 /**
  * struct j1939_vp2_packet - Represents the PGN 64502 Vehicle
  *                                         Position 2 packet
- * FIXME: current packet layout is guessed based on limited information:
- * https://www.isobus.net/isobus/pGNAndSPN/10801?type=PGN
  *
  * @total_satellites: Total number of satellites in view
  *           - SPN: 8128
  *           - Data Length: 1 byte
+ *           - Range: 0 to 250
  *
  * @hdop: Horizontal dilution of precision
  *           - SPN: 8129
  *           - Data Length: 1 byte
  *           - Resolution: 0.1
+ *           - Range: 0.0 to 25.0
  *
  * @vdop: Vertical dilution of precision
  *           - SPN: 8130
  *           - Data Length: 1 byte
  *           - Resolution: 0.1
+ *           - Range: 0.0 to 25.0
  *
  * @pdop: Position dilution of precision
  *           - SPN: 8131
  *           - Data Length: 1 byte
  *           - Resolution: 0.1
+ *           - Range: 0.0 to 25.0
  *
  * @tdop: Time dilution of precision
  *           - SPN: 8132
  *           - Data Length: 1 byte
  *           - Resolution: 0.1
+ *           - Range: 0.0 to 25.0
  *
  * This structure defines each component of the Vehicle Position 2 as described
  * in PGN 64502.
  */
 struct j1939_vp2_packet {
 	uint8_t total_satellites; /* SPN 8128 */
-	uint8_t hdop;			  /* SPN 8129 */
-	uint8_t vdop;			  /* SPN 8130 */
-	uint8_t pdop;			  /* SPN 8131 */
-	uint8_t tdop;			  /* SPN 8132 */
+	uint8_t hdop;             /* SPN 8129 */
+	uint8_t vdop;             /* SPN 8130 */
+	uint8_t pdop;             /* SPN 8131 */
+	uint8_t tdop;             /* SPN 8132 */
+	uint8_t unused5;          /* Always 0xFF */
+	uint8_t unused6;          /* Always 0xFF */
+	uint8_t unused7;          /* Always 0xFF */
 } __attribute__((__packed__));
 
 /**

--- a/j1939_vehicle_position/j1939_vehicle_position_cmn.h
+++ b/j1939_vehicle_position/j1939_vehicle_position_cmn.h
@@ -51,7 +51,7 @@ struct j1939_vp_err_msg {
 #define J1939_VP1_PRIO_DEFAULT				6
 #define J1939_VP1_MAX_TRANSFER_LENGH \
 	sizeof(struct j1939_vp1_packet)
-#define J1939_VP1_REPETITION_RATE_MS			5000
+#define J1939_VP1_REPETITION_RATE_MS			1000
 #define J1939_VP1_JITTER_MS				500
 
 /**

--- a/j1939_vehicle_position/j1939_vehicle_position_srv.c
+++ b/j1939_vehicle_position/j1939_vehicle_position_srv.c
@@ -270,6 +270,12 @@ static int j1939_vp2_get_data(struct j1939_vp_srv_priv *priv,
 	j1939_vp2_set_pdop(vp2p, pdop);
 	j1939_vp2_set_tdop(vp2p, tdop);
 
+	/* This PG's last 3 bytes are not assigned and hence must be set
+	 * to 0xFF as per J1939-71, section 5.2 */
+	vp2p->unused5 = 0xFF;
+	vp2p->unused6 = 0xFF;
+	vp2p->unused7 = 0xFF;
+
 	return 0;
 }
 


### PR DESCRIPTION
Please refer to the commit messages for more details!

Note that I added the missing unused bytes to VP2, which as per the J1939 must always be `0xFF`, but I'm not sure where to add that in the code (I don't see where the actual message data is built).

Edit: for reference, here are the VP1 and VP2 layouts
<img style="display:inline-block;" width="625" height="340" alt="VP1 layout" src="https://github.com/user-attachments/assets/128399ab-b307-41b3-8477-d356abc9a928" /><img style="display:inline-block;" width="625" height="340" alt="VP2 layout" src="https://github.com/user-attachments/assets/9161b0bb-f5af-4728-b4f6-68a3bf196463" />
